### PR TITLE
feat: Copier skeleton + project.godot + minimal main scene

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+*.egg-info/
+dist/
+
+# uv
+.python-version
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test output
+/tmp/test-output/

--- a/copier.yml
+++ b/copier.yml
@@ -1,0 +1,29 @@
+_subdirectory: template
+_exclude:
+  - copier.yml
+  - pyproject.toml
+  - ".github"
+  - ".git"
+  - ".gitignore"
+  - ".gitattributes"
+
+project_name:
+  type: str
+  default: "My Godot Game"
+  help: "Human-readable project name (e.g. My Awesome Game)"
+
+project_slug:
+  type: str
+  default: "{{ project_name | lower | replace(' ', '-') | replace('_', '-') | regex_replace('[^a-z0-9-]', '') }}"
+  help: "Kebab-case slug for directories and build artifacts (auto-derived from project_name)"
+
+multiplayer:
+  type: bool
+  default: false
+  help: "Include multiplayer scaffolding (NetworkManager autoload, RPC patterns)?"
+
+godot_version:
+  type: str
+  default: "4.6"
+  help: "Godot version string (must be 4.x, e.g. 4.6)"
+  validator: "{% if not godot_version | regex_search('^4\\.') %}Must be a 4.x version string (e.g. 4.6, 4.3){% endif %}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "godot-template"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["copier>=9.0"]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.1.0"
+tag_format = "v$version"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,0 +1,25 @@
+# Godot 4.x
+.godot/
+*.import
+.uid_cache
+
+# Export
+export/
+*.pck
+*.zip
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+*.swp
+*.swo
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+
+# Copier
+.copier-answers.yml

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,0 +1,19 @@
+# {{ project_name }}
+
+A Godot {{ godot_version }} project.
+
+## Setup
+
+After cloning, activate the project's git hooks and install tooling:
+
+```sh
+git config core.hooksPath tools/hooks
+pip install gdtoolkit pre-commit commitizen
+pre-commit install
+```
+
+## Development
+
+See `docs/gdscript-conventions.md` for typing rules and toolchain pitfalls.
+
+See `CLAUDE.md` for agent workflow, quality gates, and conventions.

--- a/template/project.godot.jinja
+++ b/template/project.godot.jinja
@@ -1,0 +1,52 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="{{ project_name }}"
+config/version="0.1.0"
+run/main_scene="res://scenes/main.tscn"
+config/features=PackedStringArray("{{ godot_version }}")
+
+[debug]
+
+gdscript/warnings/unassigned_variable=2
+gdscript/warnings/unassigned_variable_op_assign=2
+gdscript/warnings/unused_variable=2
+gdscript/warnings/unused_local_constant=2
+gdscript/warnings/unused_private_class_variable=2
+gdscript/warnings/unused_parameter=2
+gdscript/warnings/unused_signal=0
+gdscript/warnings/shadowed_variable=0
+gdscript/warnings/shadowed_variable_base_class=0
+gdscript/warnings/shadowed_global_identifier=2
+gdscript/warnings/unreachable_code=2
+gdscript/warnings/unreachable_pattern=2
+gdscript/warnings/standalone_expression=2
+gdscript/warnings/standalone_ternary=2
+gdscript/warnings/incompatible_ternary=0
+gdscript/warnings/untyped_declaration=2
+gdscript/warnings/unsafe_property_access=2
+gdscript/warnings/unsafe_method_access=2
+gdscript/warnings/unsafe_cast=2
+gdscript/warnings/unsafe_call_argument=2
+gdscript/warnings/unsafe_void_return=2
+gdscript/warnings/static_called_on_instance=2
+gdscript/warnings/missing_tool=2
+gdscript/warnings/redundant_static_unload=2
+gdscript/warnings/redundant_await=2
+gdscript/warnings/missing_await=2
+gdscript/warnings/assert_always_true=2
+gdscript/warnings/integer_division=0
+
+[rendering]
+
+textures/canvas_textures/default_texture_filter=0
+renderer/rendering_method="gl_compatibility"

--- a/template/scenes/main.gd
+++ b/template/scenes/main.gd
@@ -1,0 +1,5 @@
+extends Node2D
+
+
+func _ready() -> void:
+	print("Project loaded successfully.")

--- a/template/scenes/main.tscn
+++ b/template/scenes/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://main"]
+
+[ext_resource type="Script" path="res://scenes/main.gd" id="1_main"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1_main")


### PR DESCRIPTION
## Task
godotsandbox-071: Copier skeleton + project.godot + minimal main scene

## Changes
- copier.yml: defines project_name (default: My Godot Game), project_slug (auto-derived kebab-case), multiplayer (bool, default false), godot_version (str, default 4.6, 4.x regex validator)
- pyproject.toml: uv project with copier>=9.0 dependency, commitizen config
- template/project.godot.jinja: config/name and config/features substituted from variables, full GDScript warning levels
- template/scenes/main.tscn + main.gd: minimal Node2D with welcome print
- template/README.md.jinja: project_name and godot_version substitution
- template/.gitignore + .gitattributes: standard Godot and Python excludes

## Testing
- copier copy --defaults --trust produces valid project.godot with config/name="My Godot Game"
- copier copy with godot_version=3.5 raises ValidationError (4.x constraint enforced)
- copier copy with project_name="My Awesome Game 2" derives project_slug="my-awesome-game-2"
- copier.yml is excluded from generated output (_subdirectory: template)
- scenes/main.tscn exists in generated output