### PR TITLE
feat: quality tooling (pre-commit, scripts/tools, git hooks)

### DIFF
--- a/template/.gdformatrc
+++ b/template/.gdformatrc
@@ -1,0 +1,7 @@
+excluded_directories: !!set
+  .git: null
+  addons: null
+  .godot: null
+line_length: 100
+safety_checks: null
+use_spaces: null

--- a/template/.gdlintrc
+++ b/template/.gdlintrc
@@ -1,0 +1,11 @@
+filter:
+  exclude:
+    - "addons/"
+    - ".godot/"
+
+disable:
+  - class-definitions-order
+  - class-variable-name
+  - max-returns
+  - max-file-lines
+  - max-public-methods

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -1,0 +1,78 @@
+repos:
+  - repo: local
+    hooks:
+      - id: godot-normalize
+        name: Normalize Godot scene/resource files
+        entry: ./scripts/tools/normalize_scenes.sh
+        language: system
+        files: '\.(tscn|tres)$|^project\.godot$'
+        pass_filenames: false
+
+      - id: nested-generics
+        name: No nested generics in GDScript
+        entry: ./scripts/tools/check_nested_generics.sh
+        language: system
+        files: '\.gd$'
+        exclude: 'addons/'
+
+      - id: preload-shadows
+        name: No const preload shadowing class_name
+        entry: ./scripts/tools/check_preload_shadows.sh
+        language: system
+        files: '\.gd$'
+        exclude: 'addons/'
+
+      - id: no-warning-ignore
+        name: No @warning_ignore in GDScript
+        entry: ./scripts/tools/check_warning_ignore.sh
+        language: system
+        files: '\.gd$'
+        exclude: 'addons/|scripts/util/config_helper\.gd|scripts/util/node_cast\.gd'
+
+      - id: type-narrowing
+        name: No type narrowing violations in GDScript
+        entry: ./scripts/tools/check_type_narrowing.sh
+        language: system
+        files: '\.gd$'
+        exclude: 'addons/'
+
+      - id: gdformat
+        name: GDScript format check
+        entry: gdformat --check
+        language: system
+        files: '\.gd$'
+        exclude: 'addons/'
+
+      - id: gdlint
+        name: GDScript lint
+        entry: gdlint
+        language: system
+        files: '\.gd$'
+        exclude: 'addons/'
+
+      - id: shader-no-return
+        name: No return in shader processor functions
+        entry: ./scripts/tools/check_shaders.sh
+        language: system
+        files: '\.gdshader$'
+
+      - id: gdtypecheck
+        name: GDScript type check (requires godot)
+        entry: ./scripts/tools/check_types.sh
+        language: system
+        files: '\.gd$'
+        exclude: 'addons/'
+
+      - id: gdtest
+        name: gdUnit4 tests (requires godot)
+        entry: ./scripts/tools/run_gdunit4_tests.sh
+        language: system
+        files: '\.gd$'
+        exclude: 'addons/'
+        pass_filenames: false
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.4.1
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/template/.vscode/extensions.json
+++ b/template/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "geequlim.godot-tools"
+  ]
+}

--- a/template/.vscode/launch.json
+++ b/template/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "GDScript: Launch Project",
+      "type": "godot",
+      "request": "launch",
+      "project": "${workspaceFolder}",
+      "debug_collisions": false,
+      "debug_paths": false,
+      "debug_navigation": false,
+      "additional_options": ""
+    }
+  ]
+}

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "godotTools.inlayHints.gdscript": true
+}

--- a/template/Makefile
+++ b/template/Makefile
@@ -1,0 +1,30 @@
+GODOT ?= godot
+GDUNIT4_SCRIPT := addons/gdUnit4/bin/GdUnitCmdTool.gd
+
+.PHONY: test test-single lint check bump
+
+## Run all gdUnit4 tests headlessly.
+test:
+	$(GODOT) --headless --path . \
+		-s $(GDUNIT4_SCRIPT) \
+		-a "res://tests_gdunit4/" \
+		--ignoreHeadlessMode
+
+## Run a single test file. Usage: make test-single FILE=tests_gdunit4/test_foo.gd
+test-single:
+	$(GODOT) --headless --path . \
+		-s $(GDUNIT4_SCRIPT) \
+		-a "res://$(FILE)" \
+		--ignoreHeadlessMode
+
+## Lint all GDScript files with gdtoolkit.
+lint:
+	gdlint scripts/ tests_gdunit4/
+
+## Static analysis check (gdtoolkit format check).
+check:
+	gdformat --check scripts/ tests_gdunit4/
+
+## Bump version using conventional commits and generate changelog.
+bump:
+	cz bump --changelog

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -1,0 +1,16 @@
+[project]
+name = "{{ project_slug }}"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.1.0"
+version_files = [
+    "project.godot:config/version"
+]
+tag_format = "v$version"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/template/scripts/tools/build.sh.jinja
+++ b/template/scripts/tools/build.sh.jinja
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build script: exports Linux and Windows builds, zips them, and reports sizes.
+# Usage: ./scripts/tools/build.sh [path-to-godot] [--debug] [--version VERSION]
+
+set -euo pipefail
+
+GODOT="${1:-godot}"
+EXPORT_FLAG="--export-release"
+VERSION="dev"
+
+# Parse flags from any position
+for i in "$@"; do
+    case "$i" in
+        --debug) EXPORT_FLAG="--export-debug"; echo "Using debug export mode" ;;
+        --version) ;; # value handled below
+    esac
+done
+
+# Extract --version value
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+echo "=== Importing project resources ==="
+"$GODOT" --headless --import --path . 2>&1 | tail -1 || true
+
+echo ""
+echo "=== Exporting Linux x86_64 ==="
+mkdir -p export/linux
+"$GODOT" --headless $EXPORT_FLAG "Linux x86_64" --path .
+
+echo ""
+echo "=== Exporting Windows x86_64 ==="
+mkdir -p export/windows
+"$GODOT" --headless $EXPORT_FLAG "Windows x86_64" --path .
+
+echo ""
+echo "=== Packaging (version: ${VERSION}) ==="
+(cd export/linux && zip -9 "../../{{ project_slug }}-${VERSION}-linux-x86_64.zip" {{ project_slug }}.x86_64)
+(cd export/windows && zip -9 "../../{{ project_slug }}-${VERSION}-windows-x86_64.zip" {{ project_slug }}.exe {{ project_slug }}.console.exe 2>/dev/null || \
+  zip -9 "../../{{ project_slug }}-${VERSION}-windows-x86_64.zip" {{ project_slug }}.exe)
+
+echo ""
+echo "=== Build sizes ==="
+ls -lh "{{ project_slug }}-${VERSION}-linux-x86_64.zip" "{{ project_slug }}-${VERSION}-windows-x86_64.zip"
+echo ""
+echo "Build complete!"

--- a/template/scripts/tools/check_all_scripts.gd
+++ b/template/scripts/tools/check_all_scripts.gd
@@ -1,0 +1,67 @@
+## Tool script that forces compilation of ALL .gd and .tscn files in the project.
+## Run via: godot --headless --path . --script res://scripts/tools/check_all_scripts.gd
+## Uses _process() instead of _init() so autoloads are registered first.
+extends SceneTree
+
+var _has_run := false
+
+
+func _process(_delta: float) -> bool:
+	if _has_run:
+		return false
+	_has_run = true
+
+	var gd_files := _collect_files("res://", ".gd")
+	var tscn_files := _collect_files("res://", ".tscn")
+
+	var total := gd_files.size() + tscn_files.size()
+	print(
+		(
+			"check_all_scripts: loading %d files (%d .gd, %d .tscn)"
+			% [
+				total,
+				gd_files.size(),
+				tscn_files.size(),
+			]
+		)
+	)
+
+	for path: String in gd_files:
+		ResourceLoader.load(path)
+
+	for path: String in tscn_files:
+		ResourceLoader.load(path)
+
+	print("check_all_scripts: done")
+	quit()
+	return false
+
+
+func _collect_files(base_dir: String, extension: String) -> Array[String]:
+	var result: Array[String] = []
+	var dirs: Array[String] = [base_dir]
+
+	while dirs.size() > 0:
+		var current: String = dirs[dirs.size() - 1]
+		dirs.resize(dirs.size() - 1)
+		var dir := DirAccess.open(current)
+		if dir == null:
+			continue
+
+		dir.list_dir_begin()
+		var entry := dir.get_next()
+		while entry != "":
+			var full_path := current.path_join(entry)
+			if dir.current_is_dir():
+				if not _is_excluded(entry):
+					dirs.append(full_path)
+			elif entry.ends_with(extension):
+				result.append(full_path)
+			entry = dir.get_next()
+		dir.list_dir_end()
+
+	return result
+
+
+func _is_excluded(dir_name: String) -> bool:
+	return dir_name == "addons" or dir_name == ".godot" or dir_name == ".claude"

--- a/template/scripts/tools/check_nested_generics.sh
+++ b/template/scripts/tools/check_nested_generics.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pre-commit hook: detect nested generics in GDScript files.
+# gdtoolkit cannot parse Type[Type[...]] syntax (e.g., Array[Dictionary[K, V]]).
+# See docs/gdscript-conventions.md for the approved pattern.
+
+set -euo pipefail
+
+status=0
+
+for file in "$@"; do
+    [ -f "$file" ] || continue
+
+    line_num=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Strip trailing comment (everything after first unquoted #)
+        # Simple approach: remove from first # that is not inside a string
+        code="${line%%#*}"
+
+        # Strip string literals (single and double quoted)
+        code=$(echo "$code" | sed -E 's/"[^"]*"//g; s/'\''[^'\'']*'\''//g')
+
+        # Check for nested generics: a second [ before the first ] closes
+        if echo "$code" | grep -qE '(Array|Dictionary)\[[^]]*\['; then
+            echo "$file:$line_num: $line"
+            status=1
+        fi
+    done < "$file"
+done
+
+if [ "$status" -ne 0 ]; then
+    echo ""
+    echo "ERROR: Nested generics detected. gdtoolkit cannot parse Type[Type[...]]."
+    echo "Flatten the outer container and use a doc comment for the intended type."
+    echo "See docs/gdscript-conventions.md for details."
+fi
+
+exit "$status"

--- a/template/scripts/tools/check_preload_shadows.sh
+++ b/template/scripts/tools/check_preload_shadows.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Pre-commit hook: detect const preload(...) that shadows a class_name declaration.
+# When a script declares `class_name Foo`, any other file doing `const Foo = preload(...)`
+# shadows the global name and causes Godot warnings.
+# See docs/gdscript-conventions.md for context.
+
+set -euo pipefail
+
+# Collect all class_name declarations from the project (excluding addons)
+class_names=$(grep -rh '^class_name ' scripts/ | sed 's/class_name //' | tr -d '\r' | sort -u)
+
+if [ -z "$class_names" ]; then
+    exit 0
+fi
+
+status=0
+
+for file in "$@"; do
+    [ -f "$file" ] || continue
+
+    line_num=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Match: const SomeName = preload(  or  const SomeName := preload(
+        if echo "$line" | grep -qE '^const [A-Za-z_][A-Za-z0-9_]* :?= preload\('; then
+            # Extract the const name
+            const_name=$(echo "$line" | sed -E 's/^const ([A-Za-z_][A-Za-z0-9_]*) :?= preload\(.*/\1/')
+
+            # Check if it matches any class_name
+            if echo "$class_names" | grep -qxF "$const_name"; then
+                echo "$file:$line_num: $line"
+                status=1
+            fi
+        fi
+    done < "$file"
+done
+
+if [ "$status" -ne 0 ]; then
+    echo ""
+    echo "ERROR: const preload(...) shadows a class_name declaration."
+    echo "When a class_name is registered globally, re-declaring it as a const preload"
+    echo "shadows the global name and causes Godot warnings."
+    echo "Fix: remove the const preload line — use the class_name directly."
+fi
+
+exit "$status"

--- a/template/scripts/tools/check_shaders.sh
+++ b/template/scripts/tools/check_shaders.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Pre-commit hook: detect `return` statements inside shader processor functions.
+# Godot shader processor functions (fragment, vertex, light) do not support
+# `return` — it causes runtime shader compilation errors.
+# Helper functions may use `return` freely.
+
+set -euo pipefail
+
+status=0
+
+for file in "$@"; do
+    [ -f "$file" ] || continue
+
+    in_processor=0
+    brace_depth=0
+    processor_brace_start=0
+    in_block_comment=0
+    line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Track block comment state
+        remaining="$line"
+        if [ "$in_block_comment" -eq 1 ]; then
+            if echo "$remaining" | grep -q '\*/'; then
+                remaining="${remaining#*\*/}"
+                in_block_comment=0
+            else
+                continue
+            fi
+        fi
+
+        # Remove block comments that start and end on the same line
+        while echo "$remaining" | grep -q '/\*'; do
+            before="${remaining%%/\**}"
+            after="${remaining#*/\*}"
+            if echo "$after" | grep -q '\*/'; then
+                after="${after#*\*/}"
+                remaining="${before}${after}"
+            else
+                remaining="$before"
+                in_block_comment=1
+                break
+            fi
+        done
+
+        # Strip line comments
+        code="${remaining%%//*}"
+
+        # Detect processor function entry: void fragment|vertex|light(...)
+        if echo "$code" | grep -qE 'void\s+(fragment|vertex|light)\s*\('; then
+            in_processor=1
+            processor_brace_start=0
+        fi
+
+        # Count braces to track scope
+        open_count=$(echo "$code" | tr -cd '{' | wc -c)
+        close_count=$(echo "$code" | tr -cd '}' | wc -c)
+
+        if [ "$in_processor" -eq 1 ] && [ "$processor_brace_start" -eq 0 ] && [ "$open_count" -gt 0 ]; then
+            processor_brace_start=$((brace_depth + 1))
+        fi
+
+        brace_depth=$((brace_depth + open_count - close_count))
+
+        # Check for return inside processor function (depth > processor start)
+        if [ "$in_processor" -eq 1 ] && [ "$processor_brace_start" -gt 0 ]; then
+            if echo "$code" | grep -qE '\breturn\b'; then
+                echo "$file:$line_num: $line"
+                status=1
+            fi
+        fi
+
+        # Exited processor function
+        if [ "$in_processor" -eq 1 ] && [ "$processor_brace_start" -gt 0 ] && [ "$brace_depth" -lt "$processor_brace_start" ]; then
+            in_processor=0
+            processor_brace_start=0
+        fi
+    done < "$file"
+done
+
+if [ "$status" -ne 0 ]; then
+    echo ""
+    echo "ERROR: 'return' statement found inside a shader processor function."
+    echo "Godot shader processor functions (fragment, vertex, light) do not support 'return'."
+    echo "Restructure the logic using if/else blocks instead of early returns."
+fi
+
+exit "$status"

--- a/template/scripts/tools/check_type_narrowing.sh
+++ b/template/scripts/tools/check_type_narrowing.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Pre-commit hook: detect type narrowing anti-pattern in GDScript files.
+# Catches accessing Node2D/CanvasItem properties on variables typed as Node.
+# See docs/gdscript-conventions.md for the approved pattern.
+
+set -euo pipefail
+
+status=0
+
+# Properties that only exist on Node2D or CanvasItem, not on Node
+PROPS="global_position|position|rotation|modulate|scale|z_index|global_rotation|global_scale|visible"
+
+for file in "$@"; do
+    [ -f "$file" ] || continue
+    [[ "$file" == *.gd ]] || continue
+
+    # Track Node-typed variables with their declaration indent level.
+    # Format: "indent:varname" per entry.
+    # A variable goes out of scope when we hit a non-blank line at <= its indent.
+    # For "for" loops, the body indent is declaration_indent + 1 tab.
+    declare -a scope_vars=()
+    declare -a scope_indents=()
+    # For loop vars, the scope starts INSIDE the loop (indent > declaration indent).
+    # For var := patterns, the scope is the same block (indent >= declaration indent).
+    declare -a scope_types=() # "for" or "var"
+
+    line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Skip blank lines (don't affect scoping)
+        if [[ "$line" =~ ^[[:space:]]*$ ]]; then
+            continue
+        fi
+
+        # Calculate indent level (count leading tabs)
+        stripped="${line#"${line%%[!	]*}"}"
+        indent=$(( ${#line} - ${#stripped} ))
+
+        # Expire out-of-scope variables.
+        # For "for" vars: expire when indent <= declaration indent (left the loop body)
+        # For "var" vars: expire when indent < declaration indent (left the block)
+        new_vars=()
+        new_indents=()
+        new_types=()
+        for i in "${!scope_vars[@]}"; do
+            var_indent="${scope_indents[$i]}"
+            var_type="${scope_types[$i]}"
+            if [ "$var_type" = "for" ]; then
+                # Loop body is indented more than the for line
+                if [ "$indent" -gt "$var_indent" ]; then
+                    new_vars+=("${scope_vars[$i]}")
+                    new_indents+=("$var_indent")
+                    new_types+=("$var_type")
+                fi
+            else
+                # var := in a block - stays in scope at same or deeper indent
+                if [ "$indent" -ge "$var_indent" ]; then
+                    new_vars+=("${scope_vars[$i]}")
+                    new_indents+=("$var_indent")
+                    new_types+=("$var_type")
+                fi
+            fi
+        done
+        scope_vars=("${new_vars[@]+"${new_vars[@]}"}")
+        scope_indents=("${new_indents[@]+"${new_indents[@]}"}")
+        scope_types=("${new_types[@]+"${new_types[@]}"}")
+
+        # Strip trailing comment
+        code="${line%%#*}"
+
+        # Detect "for <varname>: Node in" (but not "for <varname>: Node2D in" etc.)
+        if echo "$code" | grep -qE 'for[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*:[[:space:]]*Node[[:space:]]+in[[:space:]]'; then
+            varname=$(echo "$code" | sed -nE 's/.*for[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*:[[:space:]]*Node[[:space:]]+in[[:space:]].*/\1/p')
+            if [ -n "$varname" ]; then
+                scope_vars+=("$varname")
+                scope_indents+=("$indent")
+                scope_types+=("for")
+            fi
+        fi
+
+        # Detect "var <varname> := get_node_or_null(" or "var <varname> := get_parent()"
+        if echo "$code" | grep -qE 'var[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*:=[[:space:]]*(get_node_or_null|get_parent)[[:space:]]*\('; then
+            varname=$(echo "$code" | sed -nE 's/.*var[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*:=[[:space:]]*(get_node_or_null|get_parent).*/\1/p')
+            if [ -n "$varname" ]; then
+                scope_vars+=("$varname")
+                scope_indents+=("$indent")
+                scope_types+=("var")
+            fi
+        fi
+
+        # Check if any in-scope Node-typed variable accesses a flagged property
+        for var in "${scope_vars[@]+"${scope_vars[@]}"}"; do
+            if echo "$code" | grep -qE "(^|[^a-zA-Z0-9_])${var}\.(${PROPS})([^a-zA-Z0-9_]|$)"; then
+                echo "$file:$line_num: $line"
+                status=1
+            fi
+        done
+    done < "$file"
+
+    unset scope_vars scope_indents scope_types
+done
+
+if [ "$status" -ne 0 ]; then
+    echo ""
+    echo "ERROR: Type narrowing violation detected."
+    echo "Accessing Node2D/CanvasItem properties on a Node-typed variable is unsafe."
+    echo "Fix: use a typed local variable after an 'is' guard, or tighten the collection type."
+    echo "See docs/gdscript-conventions.md for details."
+fi
+
+exit "$status"

--- a/template/scripts/tools/check_types.sh
+++ b/template/scripts/tools/check_types.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Validates all GDScript files by loading every .gd and .tscn in the project.
+# Uses check_all_scripts.gd to force-load all files, not just main-scene-reachable ones.
+# Usage: ./scripts/tools/check_types.sh [path-to-godot]
+# File arguments (from pre-commit) are accepted but ignored — Godot needs full
+# project context to resolve autoloads, so we always check all files.
+# Exit code 0 = clean, non-zero = errors found.
+
+set -euo pipefail
+
+GODOT="${1:-${GODOT:-godot}}"
+# Shift past the godot arg; remaining args (file list from pre-commit) are ignored.
+shift 2>/dev/null || true
+
+if ! command -v "$GODOT" &>/dev/null; then
+    echo "❌ FAILED: GDScript type check — '$GODOT' not found" >&2
+    echo "   Type errors (Variant inference, missing classes) will NOT be caught." >&2
+    echo "   Install Godot or set GODOT= to enable this check." >&2
+    echo "   To bypass: SKIP=gdtypecheck git commit ..." >&2
+    exit 1
+fi
+
+# Rebuild the global script class cache (mirrors CI's --import step).
+# Without this, newly-added class_name scripts won't be resolved.
+timeout 120 "$GODOT" --headless --import --path . --quit 2>/dev/null || true
+
+output=$(timeout 120 "$GODOT" --headless --path . --script res://scripts/tools/check_all_scripts.gd 2>&1) || true
+
+# Filter out the version banner, noise, and the tool script's own backtrace lines
+echo "$output" | grep -v "^Godot Engine v" | grep -v "^$" | grep -v "check_all_scripts\.gd" || true
+
+if echo "$output" | grep -v "check_all_scripts\.gd" | grep -qiE "(SCRIPT ERROR|Parse Error|Cannot infer|^ERROR)"; then
+    echo ""
+    echo "GDScript type check FAILED — see errors above."
+    exit 1
+fi
+
+echo "GDScript type check passed."
+exit 0

--- a/template/scripts/tools/check_uids.sh
+++ b/template/scripts/tools/check_uids.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Audit script: ensures every .gd, .gdshader, .gdextension file has a .uid sidecar.
+# Exits non-zero if any are missing. Usable from pre-commit hook and CI.
+
+set -euo pipefail
+
+UID_EXTENSIONS="gd gdshader gdextension"
+
+# Build find pattern: -name '*.gd' -o -name '*.gdshader' -o ...
+find_args=()
+first=true
+for ext in $UID_EXTENSIONS; do
+    if [ "$first" = true ]; then
+        first=false
+    else
+        find_args+=(-o)
+    fi
+    find_args+=(-name "*.${ext}")
+done
+
+# Find all matching files, excluding .godot/ and addons/gut/
+missing=()
+while IFS= read -r file; do
+    uid_file="${file}.uid"
+    if [ ! -f "$uid_file" ]; then
+        missing+=("$file")
+    fi
+done < <(find . -type f \( "${find_args[@]}" \) \
+    -not -path './.godot/*' \
+    -not -path './addons/gut/*' \
+    | sort)
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: ${#missing[@]} file(s) missing .uid sidecar:"
+    for f in "${missing[@]}"; do
+        echo "  $f"
+    done
+    echo ""
+    echo "Fix: commit via the pre-commit hook (auto-generates .uid files)"
+    echo "  or manually create: echo 'uid://<13-char-id>' > <file>.uid"
+    exit 1
+fi
+
+echo "OK: all ${UID_EXTENSIONS} files have .uid sidecars"
+exit 0

--- a/template/scripts/tools/check_warning_ignore.sh
+++ b/template/scripts/tools/check_warning_ignore.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Reject @warning_ignore annotations in GDScript files.
+# Only config_helper.gd and node_cast.gd are exempt (centralized casting).
+set -euo pipefail
+
+found=0
+for file in "$@"; do
+    [ -f "$file" ] || continue
+    if grep -n '@warning_ignore' "$file"; then
+        found=1
+    fi
+done
+
+if [ "$found" -ne 0 ]; then
+    echo ""
+    echo "ERROR: @warning_ignore is banned."
+    echo "Use typed data classes, ConfigHelper, or NodeCast instead."
+    echo "See docs/gdscript-conventions.md for details."
+    exit 1
+fi

--- a/template/scripts/tools/cleanup-worktrees.sh
+++ b/template/scripts/tools/cleanup-worktrees.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Removes stale git worktrees under .claude/worktrees/ that are older than 4 hours.
+# Safe: only targets worktrees within .claude/worktrees/, never the main worktree.
+# Idempotent: safe to run multiple times.
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORKTREE_DIR="${REPO_ROOT}/.claude/worktrees"
+AGE_MINUTES=240
+
+if [[ ! -d "$WORKTREE_DIR" ]]; then
+  echo "No stale worktrees found."
+  exit 0
+fi
+
+removed=0
+
+while IFS= read -r -d '' worktree_path; do
+  # Only process directories that are registered as git worktrees
+  if ! git worktree list --porcelain | grep -q "^worktree ${worktree_path}$"; then
+    continue
+  fi
+
+  echo "Removing stale worktree: ${worktree_path}"
+  git worktree remove "$worktree_path" --force
+  ((removed++))
+done < <(find "$WORKTREE_DIR" -mindepth 1 -maxdepth 1 -type d -mmin "+${AGE_MINUTES}" -print0)
+
+if [[ $removed -eq 0 ]]; then
+  echo "No stale worktrees found."
+else
+  echo "Removed ${removed} stale worktree(s)."
+fi

--- a/template/scripts/tools/merge-guard.sh
+++ b/template/scripts/tools/merge-guard.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <PR-NUMBER>" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+
+echo "Waiting for all checks on PR #${PR_NUMBER} to complete..."
+if ! gh pr checks "$PR_NUMBER" --watch --fail-fast; then
+  echo "ERROR: Some checks failed on PR #${PR_NUMBER}." >&2
+  echo "Fix the failing checks before merging." >&2
+  exit 1
+fi
+
+echo "All checks passed. Merging PR #${PR_NUMBER}..."
+gh pr merge "$PR_NUMBER" --squash --delete-branch
+echo "PR #${PR_NUMBER} merged successfully."

--- a/template/scripts/tools/normalize_scenes.sh
+++ b/template/scripts/tools/normalize_scenes.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Normalizes .tscn, .tres, and project.godot files by running Godot's headless
+# import pipeline, which re-serializes them to canonical format (property
+# ordering, UIDs, load_steps, section order).
+# Usage: ./scripts/tools/normalize_scenes.sh [path-to-godot]
+# File arguments (from pre-commit) are accepted but ignored — Godot needs full
+# project context, so we always normalize all files.
+# Exit code 0 = clean or skipped, non-zero = error.
+
+set -euo pipefail
+
+GODOT="${1:-godot}"
+# Shift past the godot arg; remaining args (file list from pre-commit) are ignored.
+shift 2>/dev/null || true
+
+if ! command -v "$GODOT" &>/dev/null; then
+    echo "Scene normalization SKIPPED — '$GODOT' not found"
+    exit 0
+fi
+
+echo "Normalizing Godot scene/resource files..."
+output=$(timeout 120 "$GODOT" --headless --import --path . 2>&1) || true
+
+# Report what changed
+changed=$(git diff --name-only -- '*.tscn' '*.tres' 'project.godot' 2>/dev/null || true)
+
+if [ -n "$changed" ]; then
+    echo "Normalized files:"
+    echo "$changed" | while read -r f; do
+        echo "  $f"
+    done
+else
+    echo "All scene/resource files already normalized."
+fi
+
+exit 0

--- a/template/scripts/tools/run_gdunit4_tests.sh
+++ b/template/scripts/tools/run_gdunit4_tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Runs gdUnit4 tests in headless mode via the gdUnit4 CLI addon.
+# Usage: ./scripts/tools/run_gdunit4_tests.sh [path-to-godot]
+# File arguments (from pre-commit) are accepted but ignored — gdUnit4 runs all
+# tests from the specified directory.
+# Exit code 0 = all tests passed, non-zero = failures or errors.
+# NOTE: This script is NOT added to pre-commit — it is run manually.
+
+set -euo pipefail
+
+GODOT="${1:-${GODOT:-godot}}"
+# Shift past the godot arg; remaining args (file list) are ignored.
+shift 2>/dev/null || true
+
+if ! command -v "$GODOT" &>/dev/null; then
+    echo "FAILED: gdUnit4 tests — '$GODOT' not found" >&2
+    echo "   Tests will NOT be run." >&2
+    echo "   Install Godot or set GODOT= to enable this check." >&2
+    exit 1
+fi
+
+GDUNIT4_TIMEOUT="${GDUNIT4_TIMEOUT:-120}"
+
+# Capture output to a temp file to avoid bash variable size/encoding issues
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+
+timeout "$GDUNIT4_TIMEOUT" "$GODOT" --headless --path . \
+    -s addons/gdUnit4/bin/GdUnitCmdTool.gd \
+    -a "res://tests_gdunit4/" \
+    --ignoreHeadlessMode \
+    >"$tmpfile" 2>&1 \
+    && gdunit_exit=0 || gdunit_exit=$?
+
+# Show output (filter noise)
+grep -v "^Godot Engine v" "$tmpfile" | grep -v "^$" || true
+
+# gdUnit4 exit codes: 0=success, 101=warnings (orphans), others=failures/errors
+if [ "$gdunit_exit" -eq 0 ] || [ "$gdunit_exit" -eq 101 ]; then
+    if [ "$gdunit_exit" -eq 101 ]; then
+        echo ""
+        echo "gdUnit4 tests passed with warnings (orphan nodes detected)."
+    else
+        echo "gdUnit4 tests passed."
+    fi
+    exit 0
+fi
+
+echo ""
+echo "gdUnit4 tests FAILED (exit code $gdunit_exit) — see errors above."
+exit 1

--- a/template/scripts/tools/smoke_test.gd
+++ b/template/scripts/tools/smoke_test.gd
@@ -1,0 +1,35 @@
+extends SceneTree
+## Smoke test: loads the main scene, runs ~120 frames, then quits.
+## Errors in autoload _ready() or scene loading will cause Godot to emit
+## SCRIPT ERROR: on stderr or crash with non-zero exit.
+## Uses run/main_scene from project.godot so this works without modification.
+
+var _frame_count := 0
+const MAX_FRAMES := 120
+
+
+func _initialize() -> void:
+	var main_scene_path: String = ProjectSettings.get_setting(
+		"application/run/main_scene", ""
+	)
+	if main_scene_path.is_empty():
+		print("SMOKE TEST FAIL: run/main_scene not set in project.godot")
+		quit(1)
+		return
+
+	var scene: PackedScene = load(main_scene_path)
+	if scene == null:
+		print("SMOKE TEST FAIL: could not load %s" % main_scene_path)
+		quit(1)
+		return
+	var instance: Node = scene.instantiate()
+	root.add_child(instance)
+
+
+func _process(_delta: float) -> bool:
+	_frame_count += 1
+	if _frame_count >= MAX_FRAMES:
+		print("SMOKE TEST PASS: %d frames completed" % _frame_count)
+		quit(0)
+		return true
+	return false

--- a/template/scripts/tools/smoke_test.sh
+++ b/template/scripts/tools/smoke_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Smoke test: loads the main scene (from run/main_scene in project.godot) headlessly
+# for ~120 frames. Fails if Godot exits non-zero or emits SCRIPT ERROR:.
+# Usage: ./scripts/tools/smoke_test.sh [path-to-godot]
+
+set -euo pipefail
+
+GODOT="${1:-godot}"
+OUTPUT=$("$GODOT" --headless --script res://scripts/tools/smoke_test.gd --path . 2>&1) || {
+    echo "FAIL: Godot exited with non-zero status"
+    echo "$OUTPUT"
+    exit 1
+}
+
+if echo "$OUTPUT" | grep -q "SCRIPT ERROR:"; then
+    echo "FAIL: SCRIPT ERROR detected in output"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+echo "OK: smoke test passed"
+echo "$OUTPUT" | tail -1

--- a/template/tests_gdunit4/helpers/test_helper.gd
+++ b/template/tests_gdunit4/helpers/test_helper.gd
@@ -1,0 +1,5 @@
+## Shared test utilities for this project.
+## Add project-specific setup/reset helpers here as your project grows.
+## See docs/testing-conventions.md for patterns and conventions.
+class_name GdUnitTestHelper
+extends Object

--- a/template/tools/hooks/commit-msg
+++ b/template/tools/hooks/commit-msg
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Bridge to pre-commit framework (commitizen commit-msg validation)
+if command -v pre-commit &>/dev/null; then
+    pre-commit run --hook-stage commit-msg --commit-msg-filename "$1" || exit $?
+else
+    echo "commit-msg: WARNING -- pre-commit not installed; skipping commit message validation"
+fi

--- a/template/tools/hooks/pre-commit
+++ b/template/tools/hooks/pre-commit
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Pre-commit hook: auto-generate missing .uid sidecar files for staged .gd, .gdshader,
+# and .gdextension files, then bridge to the pre-commit framework (gdformat, gdlint,
+# typecheck, normalization).
+# Godot 4.6 requires a .uid file for every .gd, .gdshader, and .gdextension file.
+
+staged_uid_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(gd|gdshader|gdextension)$' || true)
+
+# Capture originally-staged scene/resource files BEFORE pre-commit runs normalization
+originally_staged_scenes=$(git diff --cached --name-only -- '*.tscn' '*.tres' 'project.godot' 2>/dev/null || true)
+
+# --- UID sidecar generation for .gd, .gdshader, .gdextension files ---
+if [ -n "$staged_uid_files" ]; then
+    generated=()
+
+    while IFS= read -r gd_file; do
+        uid_file="${gd_file}.uid"
+
+        # Skip if .uid is already staged or tracked
+        if git ls-files --cached -- "$uid_file" | grep -q .; then
+            continue
+        fi
+
+        # Skip if .uid exists on disk (maybe just not staged — stage it)
+        if [ -f "$uid_file" ]; then
+            git add "$uid_file"
+            generated+=("$uid_file (staged existing)")
+            continue
+        fi
+
+        # Generate a random uid: 13 chars from [a-z0-9]
+        random_id=$(tr -dc 'a-z0-9' < /dev/urandom | head -c 13)
+        echo "uid://${random_id}" > "$uid_file"
+        git add "$uid_file"
+        generated+=("$uid_file (created)")
+    done <<< "$staged_uid_files"
+
+    if [ ${#generated[@]} -gt 0 ]; then
+        echo "pre-commit: auto-generated .uid sidecar files:"
+        for f in "${generated[@]}"; do
+            echo "  $f"
+        done
+    fi
+fi
+
+# Bridge to pre-commit framework (gdformat, gdlint, typecheck, normalization)
+if command -v pre-commit &>/dev/null; then
+    pre-commit run --hook-stage pre-commit || exit $?
+else
+    echo "pre-commit: WARNING — 'pre-commit' not installed; skipping gdformat/gdlint/typecheck"
+    echo "pre-commit: Run 'pip install pre-commit && pre-commit install' to enable validation"
+fi
+
+# Re-stage only originally-staged scene/resource files that were modified by normalization
+if [ -n "$originally_staged_scenes" ]; then
+    changed=$(echo "$originally_staged_scenes" | while read -r f; do
+        git diff --quiet -- "$f" 2>/dev/null || echo "$f"
+    done)
+    if [ -n "$changed" ]; then
+        echo "$changed" | xargs git add
+        echo "pre-commit: re-staged normalized Godot files"
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## Task
godotsandbox-e6d: Quality tooling: pre-commit, scripts/tools, git hooks

## Changes
- .pre-commit-config.yaml: all hooks minus generate-theme (nested-generics, preload-shadows, no-warning-ignore, type-narrowing, gdformat, gdlint, shader-no-return, gdtypecheck, gdtest, commitizen)
- .gdformatrc, .gdlintrc: gdtoolkit config with 100-char line limit
- scripts/tools/: check_nested_generics, check_preload_shadows, check_warning_ignore, check_type_narrowing, check_shaders, check_types, check_all_scripts.gd, normalize_scenes, run_gdunit4_tests, merge-guard, cleanup-worktrees, check_uids
- scripts/tools/smoke_test.gd: generalized to use run/main_scene from project.godot (not hardcoded)
- scripts/tools/smoke_test.sh: wrapper for smoke_test.gd
- scripts/tools/build.sh.jinja: artifact names use project_slug Jinja2 variable
- template/pyproject.toml.jinja: project name uses project_slug variable
- Makefile: gdUnit4 test runner commands
- tools/hooks/pre-commit, commit-msg: uid sidecar generation + pre-commit framework bridge
- .vscode/extensions.json, settings.json, launch.json
- tests_gdunit4/helpers/test_helper.gd: empty class scaffold

## Testing
- smoke_test.gd uses ProjectSettings.get_setting("application/run/main_scene") — no game-specific path
- No generate_theme references anywhere
- tools/hooks/pre-commit is executable (chmod +x applied)
- build.sh.jinja uses project_slug for artifact naming