### PR TITLE
feat: CLAUDE.md + documentation scaffold

### DIFF
--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -1,0 +1,250 @@
+# CLAUDE.md — {{ project_name }}
+
+## Tech Stack
+- Godot {{ godot_version }}, GDScript
+
+## GDScript Conventions
+
+See `docs/gdscript-conventions.md` for typing rules and known toolchain pitfalls.
+Key rules enforced by pre-commit:
+- No nested generics (`Array[Dict[K,V]]`) — gdtoolkit parser limitation
+- No `@warning_ignore` annotations (pre-commit enforced) — use typed data classes, ConfigHelper, NodeCast
+- 100-char line limit (gdformat)
+
+## Setup
+
+After cloning, activate the project's git hooks and install tooling:
+
+```sh
+git config core.hooksPath tools/hooks
+pip install gdtoolkit pre-commit commitizen
+pre-commit install
+gh extension install agynio/gh-pr-review
+```
+
+## Session Isolation (MANDATORY)
+
+At the start of every session, before doing anything else (including Environment Bootstrap), call `EnterWorktree` to isolate this session in its own git worktree. This enables parallel Overseer sessions without conflicts.
+
+- Do NOT skip this step, even for quick tasks
+- Plan files, scratch state, and sub-agent worktrees are all worktree-local
+- Ready and Campfire communicate over TCP — they work from any worktree
+- Sub-agents launched with `isolation: "worktree"` work correctly from within a worktree
+
+## Worktree Cleanup
+
+ALL agents — including the Overseer — **must** clean up their worktree before finishing:
+
+1. Ensure all work is committed and pushed (or discarded)
+2. Change back to the main repo
+3. Remove the worktree: `git worktree remove .claude/worktrees/<worktree-name> --force`
+
+Do not leave stale worktrees behind. If stale worktrees exist from previous sessions, clean them up:
+`git worktree list` to find them, then remove with the command above.
+
+## Overseer Role (MANDATORY)
+
+The Overseer (top-level Claude Code session) does NOT write code. Ever.
+
+- **Delegate Planning**: Launch Architect agent when user has a feature/idea/problem
+- **Delegate Execution**: Launch Daemon agent when Ready issues exist
+- **Handle Escalations**: Resolve blockers the Daemon can't handle, relay to user when needed
+
+If you catch yourself about to use Edit, Write, or Bash to modify project files:
+STOP. That is a Developer agent's job. Create a Ready issue and delegate instead.
+
+The only files the Overseer may edit are:
+- `CLAUDE.md` and files under `.claude/` (configuration/memory)
+- Plan files under `.claude/plans/`
+
+**Plan mode** is for infrastructure/config changes the Overseer handles itself (updating CLAUDE.md,
+agent definitions, settings). It is NOT used for feature work — Architect replaces that.
+
+**No exceptions for "small" or "trivial" changes.** The escape hatch is `[manually]` in the user's message.
+
+## Architect Launch Protocol (MANDATORY)
+
+When a user describes a feature, idea, bug, or problem:
+
+1. **Launch the Architect agent**: Use the Agent tool with `subagent_type: "pm"` (uses architect.md)
+   - Pass the user's description in the prompt
+   - Run in foreground — Architect will interview the user
+2. Architect creates PRD, decomposes into vertical slices, creates Ready issues, then returns
+3. After Architect returns → begin Execution Protocol immediately
+4. **Do NOT ask the user what to do next** — the answer is always "launch Daemon"
+
+Any form of approval after Architect returns means start execution immediately.
+
+**Escape hatch** — skip Architect and implement directly when the user's
+message contains `[manually]` (e.g., "[manually] update this file").
+
+## Execution Protocol (MANDATORY)
+
+When Ready issues exist (from Architect or manual creation):
+
+1. **Check queue**: `rd ready --json`
+2. If issues exist, **launch the Daemon agent**: Use the Agent tool with `subagent_type: "daemon"`
+   - Pass the list of Ready issue IDs
+   - Run in foreground — monitor for escalations
+3. Daemon handles the entire Developer/Reviewer lifecycle and returns a report
+4. If Daemon escalates a blocker → Overseer resolves or relays to user, then re-launches Daemon
+5. When Daemon reports all work complete → done
+
+## Developer/Reviewer Cycles
+
+Daemon manages Developer/Reviewer cycles. If Daemon escalates after 2 failed
+Reviewer cycles, re-scope with user.
+
+## Environment Bootstrap
+
+1. Clean up stale worktrees: `./scripts/tools/cleanup-worktrees.sh`
+2. Ensure PATH includes `$HOME/.local/bin` (for `rd` and `cf`)
+3. Verify Ready: `rd status`
+4. Verify `gh auth status` for PR operations
+5. Ensure gh-pr-review extension: `gh extension list | grep -q pr-review || gh extension install agynio/gh-pr-review`
+6. Init Campfire: `cf init 2>/dev/null`
+
+## Campfire
+
+Campfire is an open protocol for AI agent coordination ([getcampfire.dev](https://getcampfire.dev)) — agents discover each other, form groups, and coordinate work via signed messages.
+
+**Agent identity isolation:** Each agent uses a separate Campfire home to avoid shared cursor conflicts:
+
+```sh
+export CF_HOME=~/.campfire-agent-$ISSUE_ID
+```
+
+**Lifecycle:** One campfire per plan. Daemon creates it when starting execution, agents join/leave
+during work, and Daemon cleans up after completion:
+
+```sh
+cf leave <campfire-id>
+```
+
+See the [Campfire docs](https://getcampfire.dev/docs/) for full protocol reference.
+
+## Ready Quick Reference
+
+```bash
+rd ready --json                              # find unblocked work
+rd show <id> --json                          # view issue details
+rd claim <id>                                # claim work (sets status to active)
+rd close <id> --reason "..." --json          # complete work
+rd done <id>                                 # shorthand for close
+```
+
+Always use `--json` flag for programmatic output. Use `rd` for ALL task tracking — no markdown TODOs.
+
+## Scene/Resource Normalization
+
+After modifying `.tscn`, `.tres`, or `project.godot` files, run:
+
+```sh
+./scripts/tools/normalize_scenes.sh
+```
+
+This runs Godot headless to normalize serialization (property ordering, UIDs, section order).
+The pre-commit hook runs this automatically when these files are staged, but run it explicitly
+to catch issues early. Skipped gracefully if `godot` is not available.
+
+## Backlog Management
+
+**GitHub Issues** = long-term backlog (ideas, future features, bugs to investigate later)
+**Ready** = active sprint work that agents are implementing right now
+
+### Workflow
+- Ideas/bugs/features get filed as GitHub Issues with labels (`backlog`, `idea`, `bug`, `enhancement`)
+- When ready to implement, a Ready issue is created linked via `--context "gh#<number>: ..."`
+- Developer/Reviewer agents work the Ready issue as normal — they don't interact with GitHub Issues
+- After all linked Ready issues are closed, Daemon closes the GitHub Issue with `gh issue close`
+
+### Fast Path
+When user says "implement X now", Architect creates Ready issues directly — no GitHub Issue needed. GitHub Issues are for the **backlog** (work not being done immediately).
+
+## PR Merge Rules
+
+Before merging any PR, agents **must** use the merge guard:
+
+```sh
+./scripts/tools/merge-guard.sh <PR-NUMBER>
+```
+
+This script waits for all checks to pass, then squash-merges and deletes the branch.
+**Never** call `gh pr merge` directly — always go through the guard script.
+
+## Session Completion (All Agents)
+
+Work is NOT complete until `git push` succeeds:
+
+1. Run quality gates if code changed
+2. Update issue status in Ready
+3. `git pull --rebase && git push`
+4. `git status` must show "up to date with origin"
+5. Leave campfire if joined: `cf leave 2>/dev/null`
+6. Clean up your worktree (see Worktree Cleanup section above)
+
+**Never** stop before pushing. **Never** say "ready to push when you are" — the agent must push.
+
+## Permission Model
+
+Bash commands are scoped to an explicit allow-list in `.claude/settings.json`. Safe commands
+(`git`, `gh`, `rd`, `ls`, `grep`, `./scripts/tools/*`, etc.) run without prompts. Unfamiliar
+or destructive commands (`rm -rf`, `curl`, `sudo`, etc.) trigger a user confirmation prompt.
+
+- **`deny` rules are not used** — they are non-functional in Claude Code (as of early 2026)
+- **Chained commands** may bypass individual patterns but still prompt if no pattern matches the first token
+- **Per-agent scoping** is not supported by the platform; behavioral guardrails in agent prompts are the primary enforcement layer
+- Read/Write/Edit/Glob/Grep/Agent are auto-allowed (`defaultMode: dontAsk`)
+
+## Pre-commit: GDScript Type Check
+
+`scripts/tools/check_types.sh` runs Godot headless to validate all GDScript files. It **requires**
+the `godot` binary and will fail (exit 1) if it is not found. To bypass when godot is unavailable:
+
+```sh
+SKIP=gdtypecheck git commit ...
+```
+
+**Important**: `.claude/.gdignore` must exist and must not be removed. It prevents Godot from
+scanning agent worktree directories during the type check, which would cause false errors.
+
+## TDD Workflow (MANDATORY for agents)
+
+All Developer agents follow test-driven development for logic changes:
+
+1. **Write failing tests first** — commit with `test(<task-id>): ...`
+2. **Implement minimum code** to make tests pass — commit with `feat(<task-id>): ...` or `fix(<task-id>): ...`
+3. **Refactor** if needed (tests must still pass)
+
+**Every bug fix must include a regression test** that reproduces the bug before the fix.
+This is the #1 rule for stopping recurring runtime errors.
+
+**What requires tests**: Logic, calculations, state transitions, data transformations.
+**What skips TDD**: Scene-only changes (.tscn/.tres), pure visual/UI, single-line config tweaks.
+
+Reviewer agents verify test-first commit ordering and block PRs missing tests for logic changes.
+
+See `docs/testing-conventions.md` for test structure, naming, and patterns.
+
+### Pre-commit test runner
+
+`scripts/tools/run_gdunit4_tests.sh` runs gdUnit4 tests headlessly on every commit (when `godot` is available).
+Bypass: `SKIP=gdtest git commit ...` (or `SKIP=gdtypecheck,gdtest` to skip both godot hooks).
+
+## Project Architecture
+
+See `docs/DECISIONS.md` for domain language, architectural patterns, collision layers, and key decisions.
+Update this file as the project evolves — agents reference it for project-specific context.
+
+## Persistent Agent Memory
+
+Each agent has a memory directory at `.claude/agent-memory/<agent-name>/`.
+
+- `MEMORY.md` auto-loads (first 200 lines). Keep it concise.
+- Create topic files for details, link from MEMORY.md.
+- Update or remove memories that turn out to be wrong or outdated.
+- Organize semantically by topic, not chronologically.
+
+**Save**: Stable patterns, architectural decisions, recurring solutions, user preferences.
+**Don't save**: Session-specific state, unverified observations, CLAUDE.md duplicates.
+**User requests**: When asked to remember something, save it immediately. When asked to forget, remove it.

--- a/template/docs/DECISIONS.md
+++ b/template/docs/DECISIONS.md
@@ -1,0 +1,32 @@
+# Architecture Decisions
+
+Record project-specific architectural decisions, domain language, and patterns here.
+Agents reference this file for project context.
+
+## Domain Language
+
+| Term | Definition |
+|---|---|
+| (add terms as your project evolves) | |
+
+## Architectural Patterns
+
+(Document your patterns: state machines, component composition, signal contracts, etc.)
+
+## Collision Layers
+
+(If using physics, document your collision layer assignments here.)
+
+| Layer | Bit | Name | Used by |
+|---|---|---|---|
+| 1 | 1 | (your layer) | |
+
+## Key Decisions
+
+### YYYY-MM-DD: Decision Title
+
+**Context:** (What situation led to this decision?)
+
+**Decision:** (What was decided?)
+
+**Consequences:** (What are the trade-offs?)

--- a/template/docs/gdscript-conventions.md
+++ b/template/docs/gdscript-conventions.md
@@ -1,0 +1,265 @@
+# GDScript Conventions
+
+Typing rules and known toolchain pitfalls for this project.
+
+## Typed Collections
+
+Always use `Array[T]` and `Dictionary[K, V]` for new code.
+Godot 4.6 enforces types at runtime, catching mismatches early.
+
+## Nested Generic Limitation
+
+gdtoolkit (gdformat/gdlint) cannot parse nested generics like `Type[Type[...]]`.
+Flatten the outer container and add a doc comment showing the intended type.
+
+```gdscript
+# BAD - breaks gdformat/gdlint
+var items: Array[Dictionary[String, Variant]] = []
+
+# GOOD - flatten outer, doc comment for intent
+var items: Array[Dictionary] = []  ## Array[Dictionary[String, Variant]]
+```
+
+A pre-commit hook (`nested-generics`) catches these before gdtoolkit fails.
+
+## Accessing Flattened Container Elements
+
+Elements extracted from a flattened container (e.g., `Array[Dictionary]`) arrive as
+the bare type at runtime. Use `NodeCast` helpers or typed data classes to safely
+access these elements without `@warning_ignore`.
+
+```gdscript
+# BAD - runtime type error (element is bare Dictionary, not Dictionary[K, V])
+var item: Dictionary[String, Variant] = items[0]
+
+# GOOD - use bare type (the cast is safe since the container enforces the type)
+var item: Dictionary = items[0]
+
+# BEST - use a typed data class instead of Dictionary
+var item := MyDataClass.new(items[0])
+```
+
+## Bare Dictionary with Doc Comment
+
+When a type cannot be expressed due to nested generics, use the bare type with a
+`##` doc comment showing the intended type.
+
+```gdscript
+var _cells: Dictionary[Vector2i, Array] = {}  ## values are Array[Node2D]
+```
+
+## Freed Node Safety
+
+Iterating a typed array that may contain freed instances crashes at the type check
+before user code runs. Connect `tree_exiting` to auto-remove, or use `NodeCast`
+to filter valid instances.
+
+```gdscript
+# BAD - crashes if array contains a freed node
+for node: Node2D in potentially_stale_array:
+    node.do_something()
+
+# GOOD - auto-cleanup prevents freed nodes in the array
+# (connect tree_exiting to unregister)
+for node: Node2D in clean_array:
+    node.do_something()
+```
+
+## 2D Arrays
+
+GDScript does not support `Array[Array[int]]`. Use `Array[Array]` instead.
+
+```gdscript
+# BAD - parse error
+var grid: Array[Array[int]] = []
+
+# GOOD
+var grid: Array[Array] = []  ## Array[Array[int]]
+```
+
+## Line Length
+
+gdformat enforces a 100-character line limit. Type annotations often push lines
+past this. Break long declarations across lines or shorten variable names.
+
+## Implicit Type Inference
+
+Prefer `:=` (inferred type) over explicit type annotations when the type is obvious
+from the right-hand side. This reduces noise and keeps declarations concise.
+
+### CONVERT to `:=`
+
+```gdscript
+# Primitive literals matching the declared type
+var health := 100
+var speed := 200.0
+var name := "Player"
+var alive := true
+
+# Constructors
+var pos := Vector2(10, 20)
+var color := Color.RED
+
+# const declarations (always inferred)
+const GRAVITY := 980.0
+
+# @onready with constructor calls (NOT $ or % paths)
+@onready var timer := Timer.new()
+@onready var tween := create_tween()
+
+# StringName and NodePath literals
+var action := &"ui_accept"
+var path := ^"Player/Sprite"
+```
+
+### DO NOT CONVERT — keep explicit types
+
+```gdscript
+# @export — inspector needs the type
+@export var max_health: int = 100
+@export var move_speed: float = 200.0
+
+# @onready with $ or % node paths — editor uses type for autocompletion
+@onready var sprite: Sprite2D = $Sprite2D
+@onready var label: Label = %ScoreLabel
+
+# Typed containers with empty literals — type would be lost
+var enemies: Array[Enemy] = []
+var scores: Dictionary[String, int] = {}
+
+# Declarations without assignment
+var target: Node2D
+
+# Function parameters and return types
+func take_damage(amount: int) -> void:
+    pass
+
+# int-to-float coercion (see pitfall below)
+var speed: float = 100
+
+# Downcasts — right-hand side type is broader than intended
+var node: Node2D = get_node("path")
+var resource: PackedScene = load("res://scene.tscn")
+```
+
+### Pitfall: int-to-float coercion
+
+Integer literals like `100` have type `int`. Using `:=` infers `int`, not `float`.
+
+```gdscript
+# BAD — speed is inferred as int, breaks float math
+var speed := 100
+
+# GOOD — explicit float type with int literal
+var speed: float = 100
+
+# ALSO GOOD — float literal, safe to infer
+var speed := 100.0
+```
+
+## Type Narrowing After `is` Checks
+
+GDScript does not narrow the original variable after `if x is Subtype:`. Always create
+a new typed local variable.
+
+```gdscript
+# BAD — checker still sees `child` as Node
+for child: Node in group:
+    if child is PlayerController:
+        child.is_dead  # Error: not present on Node
+
+# GOOD — typed local after guard
+for child: Node in group:
+    if not (child is PlayerController):
+        continue
+    var pc: PlayerController = child
+    pc.is_dead  # OK
+```
+
+## Loop Variable Shadowing
+
+Do not name a loop variable the same as a property in the base class.
+
+## Enum Literals
+
+Use the enum constant or an explicit cast instead of a bare integer for enum-typed
+properties.
+
+```gdscript
+# BAD
+center.layout_mode = 1
+
+# GOOD
+center.layout_mode = 1 as Control.LayoutMode
+```
+
+## Dictionary Value Access
+
+Values retrieved from an untyped `Dictionary` are `Variant`. Assign to a typed local
+before passing to a function that expects a concrete type.
+
+```gdscript
+# BAD — int() receives Variant
+map_generator.configure(int(data["width"]), int(data["height"]))
+
+# GOOD
+var w: int = data["width"]
+var h: int = data["height"]
+map_generator.configure(w, h)
+```
+
+## `collision_layer` Access
+
+`collision_layer` is defined on `CollisionObject2D`, not `Node2D`. When checking
+collision layers on physics bodies, cast to `CollisionObject2D` first.
+
+```gdscript
+# BAD — Node2D has no collision_layer
+for body: Node2D in area.get_overlapping_bodies():
+    if body.collision_layer & 2:  # Error
+
+# GOOD
+for body: Node2D in area.get_overlapping_bodies():
+    if not (body is CollisionObject2D):
+        continue
+    var co: CollisionObject2D = body
+    if co.collision_layer & 2:
+        pass
+```
+
+## Shader Rules
+
+`return` is banned inside shader processor functions (`fragment`, `vertex`, `light`).
+Use `if`/`else` blocks instead of early returns.
+
+A pre-commit hook (`shader-no-return`) enforces this automatically.
+
+## Type Safety Policy
+
+`@warning_ignore` annotations are **banned** in all GDScript files. The only exceptions
+are `scripts/util/config_helper.gd` and `scripts/util/node_cast.gd`, which centralize
+unavoidable casts. A pre-commit hook (`no-warning-ignore`) enforces this automatically.
+
+### What to use instead
+
+| Problem | Solution |
+|---|---|
+| Raw `Dictionary` with known keys | Create a typed data class |
+| `ConfigFile.get_value()` returns `Variant` | Use `ConfigHelper.get_string()`, `.get_int()`, etc. |
+| Node downcasting (`get_node()` returns broad type) | Use `NodeCast.as_node_2d()`, `.as_sprite()`, etc. |
+| Typed `Array.pop_back()` returns `Variant` | Use `NodeCast.pop_back_node()` |
+| Freed nodes in typed arrays | Auto-cleanup via `tree_exiting` signal |
+
+### Project-level suppressions
+
+Only `integer_division` and `unused_signal` are suppressed at the project level
+(GDScript warning level 0 in `project.godot`). These do not require per-file annotations.
+
+### Adding new unavoidable warnings
+
+If you encounter a warning that genuinely cannot be resolved with typed code:
+
+1. Check if `ConfigHelper` or `NodeCast` can handle it — add a method there if needed
+2. If not, create a new utility file with a focused purpose
+3. Add the new file to the `exclude` list in `.pre-commit-config.yaml`
+4. Never scatter `@warning_ignore` across feature code

--- a/template/docs/testing-conventions.md
+++ b/template/docs/testing-conventions.md
@@ -1,0 +1,212 @@
+# Testing Conventions
+
+gdUnit4 test patterns and conventions for this project.
+
+## File Organization
+
+All automated tests live in `tests_gdunit4/`, discovered by the gdUnit4 CLI runner.
+
+```
+tests_gdunit4/
+  test_<module>.gd            # one file per module
+  helpers/
+    test_helper.gd            # shared utilities (GdUnitTestHelper class)
+  integration/
+    test_int_smoke.gd         # integration tests
+  manual/
+    test_<feature>.md         # manual test plans for visual/physics checks
+```
+
+- **Naming:** `test_<module>.gd` -- one test file per module or script under test
+- **Helpers:** shared setup utilities in `tests_gdunit4/helpers/test_helper.gd` (`GdUnitTestHelper` class)
+- **Integration:** multi-system tests in `tests_gdunit4/integration/`
+- **Manual plans:** markdown checklists in `tests_gdunit4/manual/` for things that cannot be automated
+
+## Test Structure
+
+Every test file follows this template:
+
+```gdscript
+extends GdUnitTestSuite
+
+var subject: MyComponent
+
+
+func before_test() -> void:
+    subject = auto_free(MyComponent.new())
+    add_child(subject)
+
+
+func test_initial_state() -> void:
+    assert_bool(subject.is_active()).is_false()
+
+
+func test_activate_changes_state() -> void:
+    subject.activate()
+    assert_bool(subject.is_active()).is_true()
+```
+
+Key points:
+
+- Extend `GdUnitTestSuite`, not `Node` or `SceneTree`
+- Use `before_test()` to create a fresh subject for every test
+- One assertion concept per test function (multiple asserts are fine if they test the same thing)
+- Two blank lines between functions (matches gdformat rules)
+
+## Naming Conventions
+
+### Test functions
+
+Prefix with `test_` and describe what is being tested:
+
+```gdscript
+func test_calculate_value_zero_items() -> void:
+func test_take_damage_emits_health_changed() -> void:
+func test_vector_to_dir_north() -> void:
+func test_pop_last_empty_returns_null() -> void:
+```
+
+### Regression tests
+
+Every bug fix **must** add a regression test named `test_regression_<description>`:
+
+```gdscript
+func test_regression_dead_player_skipped_in_find_target() -> void:
+    # Reproduces the bug before the fix
+    player.is_dead = true
+    var target := system._find_target()
+    assert_object(target).is_null()
+```
+
+This is the most important convention for preventing runtime errors from recurring.
+
+### Fixture variables
+
+No leading underscore on local variables (gdlint enforces this in gdUnit4 tests).
+Use descriptive names for instance variables shared across tests.
+
+### Helper methods
+
+Underscore prefix for private factory/setup methods within a test file:
+
+```gdscript
+func _make_component(val: int = 10) -> MyComponent:
+    var comp: MyComponent = auto_free(MyComponent.new())
+    add_child(comp)
+    comp.value = val
+    return comp
+```
+
+## Node Lifecycle
+
+### Preferred: `auto_free()` + `add_child()`
+
+`auto_free()` registers the node for automatic cleanup after the test, and `add_child()`
+adds it to the scene tree:
+
+```gdscript
+func before_test() -> void:
+    subject = auto_free(MyComponent.new())
+    add_child(subject)
+```
+
+**Important:** `auto_free()` returns `Variant`, not the original type. Always use an
+explicit type annotation on the receiving variable:
+
+```gdscript
+# GOOD -- explicit type preserves type safety
+var node: Node2D = auto_free(Node2D.new())
+add_child(node)
+
+# BAD -- loses type information
+var node := auto_free(Node2D.new())  # node is Variant
+```
+
+### Manual cleanup with `after_test()`
+
+Only use when `auto_free()` is not suitable:
+
+```gdscript
+func before_test() -> void:
+    world = build_world_shell()
+    add_child(world)
+
+func after_test() -> void:
+    if is_instance_valid(world):
+        world.queue_free()
+        world = null
+```
+
+## Autoload State
+
+Autoloads persist across tests. Reset them in `before_test()` or `after_test()`
+to prevent test pollution. Add reset methods to `GdUnitTestHelper` (in `tests_gdunit4/helpers/test_helper.gd`)
+as your project grows, rather than scattering reset logic across test files.
+
+## What to Test vs Not
+
+| Category | Test? | Example |
+|---|---|---|
+| Pure logic/calculations | Yes | `calculate_slowdown(weight)` |
+| State transitions | Yes | FSM state changes |
+| Signal emission | Yes | `health_changed` on damage |
+| Data classes | Yes | Typed data containers |
+| Component behavior | Yes | `take_damage()` |
+| Visual rendering | No | Sprite appearance, animations |
+| Physics feel | Manual | Collision response, knockback |
+| UI layout | Manual | HUD positioning, menu flow |
+| Multiplayer sync | Manual | RPC delivery across peers |
+
+## Signal Testing
+
+Use `monitor_signals()` to start recording, then assert with `await assert_signal()`:
+
+```gdscript
+func test_take_damage_emits_health_changed() -> void:
+    monitor_signals(health_comp)
+    health_comp.take_damage(10.0)
+    await assert_signal(health_comp).call("is_emitted", "health_changed", [90.0, 100.0])
+```
+
+### Signal assertion gotchas
+
+- **Always include expected args** in `is_emitted` when the signal has parameters
+- **Use `.call()` syntax** -- `assert_signal()` returns a dynamic object
+- **Autoload singletons** -- do NOT use `monitor_signals()` on autoload singletons. Use a manual signal connection instead.
+
+## Common Assertions
+
+| Assertion | Purpose | Example |
+|---|---|---|
+| `assert_int(val)` | Integer comparisons | `.is_equal(42)`, `.is_greater(0)` |
+| `assert_float(val)` | Float comparisons | `.is_equal(1.0)`, `.is_equal_approx(1.0, 0.01)` |
+| `assert_str(val)` | String comparisons | `.is_equal("stone")`, `.contains("error")` |
+| `assert_bool(val)` | Boolean checks | `.is_true()`, `.is_false()` |
+| `assert_object(val)` | Object/null checks | `.is_null()`, `.is_not_null()`, `.is_equal(obj)` |
+| `assert_array(val)` | Array checks | `.has_size(3)`, `.contains([item])` |
+| `assert_signal(obj)` | Signal assertions (await) | `.call("is_emitted", "sig", [args])` |
+
+## Running Tests
+
+### Command line (headless)
+
+```bash
+./scripts/tools/run_gdunit4_tests.sh
+```
+
+### Direct invocation
+
+```bash
+godot --headless --path . \
+    -s addons/gdUnit4/bin/GdUnitCmdTool.gd \
+    -a "res://tests_gdunit4/" \
+    --ignoreHeadlessMode
+```
+
+### Pre-commit bypass
+
+The `gdtest` pre-commit hook runs tests on commit. To skip when godot is unavailable:
+
+```bash
+SKIP=gdtest git commit -m "your message"
+```


### PR DESCRIPTION
## Task
godotsandbox-17d: CLAUDE.md + documentation scaffold

## Changes
- CLAUDE.md.jinja: generalized from godot-sandbox, uses project_name and godot_version variables, removed game-specific sections
- docs/DECISIONS.md: new empty scaffold with Domain Language table, Architectural Patterns, Collision Layers, and Key Decisions sections
- docs/gdscript-conventions.md: stripped Custom FSM States section, all type safety rules kept
- docs/testing-conventions.md: stripped game-specific helper resets, generic patterns kept

## Testing
- No godot-sandbox references in CLAUDE.md (grepped clean)
- docs/DECISIONS.md has all 4 required sections (Domain Language, Architectural Patterns, Collision Layers, Key Decisions)
- docs/gdscript-conventions.md has no FSM section reference
- docs/testing-conventions.md has no game-specific resets (reset_economy, reset_game_manager, etc.)
- project_name and godot_version variables used in CLAUDE.md.jinja header