### PR TITLE
feat: skills (6 generalized skills)

### DIFF
--- a/template/.claude/skills/grill-me/SKILL.md
+++ b/template/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+When exploring the codebase or forming recommendations, reference the project's domain language and architectural patterns from `docs/DECISIONS.md`. Consider:
+- How does this fit the project's existing architecture patterns?
+- What signal contracts, component interfaces, or state machine patterns are already established?
+- What are the edge cases: error handling, freed node cleanup, edge states?
+- What does "done" look like from a testable acceptance criteria perspective?
+
+Reference `docs/DECISIONS.md` for project-specific domain language, collision layers, and architectural decisions when providing recommended answers.

--- a/template/.claude/skills/review-plan/SKILL.md
+++ b/template/.claude/skills/review-plan/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: review-plan
+description: Iteratively review the current plan file for completeness, improvements, best practices, and regression safety. Invoke with /review-plan or /review-plan <number-of-passes>. Use when the user asks to review, stress-test, or sanity-check a plan.
+allowed-tools: Read, Glob, Grep, AskUserQuestion, ExitPlanMode, Edit
+---
+
+## Instructions
+
+1. **Find the active plan file**: Glob for `.claude/plans/*.md` and read the most recent one. If no plan file exists, tell the user there is no plan to review.
+
+2. **Run review passes** (default: 5, or use $ARGUMENTS if a number is provided):
+
+   For each pass, evaluate the plan against these questions and note any issues:
+
+   - **Anything missed?** — Edge cases, error handling, affected systems, missing dependencies, untested paths
+   - **Anything to improve?** — Simpler approaches, fewer files touched, reuse of existing utilities/patterns, unnecessary complexity
+   - **Does this follow best practices?** — Project conventions (CLAUDE.md), typing rules, multiplayer patterns, architectural consistency
+   - **Does this avoid future regression?** — What could break? What tests are needed? Are there side effects on existing behavior?
+
+3. **After each pass**, write a brief summary:
+   - Pass N: [issues found or "no issues"]
+   - Suggested revisions (if any)
+
+4. **Present the final output**:
+   - A numbered list of all revisions suggested across all passes
+   - If no issues were found across all passes, say so explicitly
+   - Do NOT modify the plan file — present suggestions for the user to accept
+
+5. **Ask the user for a decision** using `AskUserQuestion`:
+   - Option 1: "Ready for handoff" — the plan is good to hand off to the Architect/Daemon agents
+   - Option 2: "Suggest changes" — the user wants to provide feedback (they can type their suggestions via the input)
+   - If the user selects "Ready for handoff", call `ExitPlanMode` so the Overseer can proceed with handoff
+   - If the user suggests changes, apply their feedback to the plan file and re-run a single review pass, then ask again
+
+## Notes
+- The review passes are read-only. The skill only edits the plan file if the user suggests changes.
+- Focus on actionable, specific feedback — not generic advice.
+- Reference specific sections of the plan when suggesting changes.

--- a/template/.claude/skills/tdd/SKILL.md
+++ b/template/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: tdd
+description: Guide test-driven development using red-green-refactor cycles with gdUnit4. Emphasizes vertical slices (one test drives one implementation), behavior-driven testing through public interfaces, and GDScript conventions. Use when implementing features, fixing bugs with TDD, or when user mentions "tdd", "test first", or "red green".
+---
+
+# Test-Driven Development (gdUnit4)
+
+## Philosophy
+
+Tests verify **behavior through public interfaces**, not implementation details. A good test reads like a specification and survives internal refactors. See [testing-philosophy.md](testing-philosophy.md).
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT** write all tests first, then all implementation. This produces tests that verify imagined behavior.
+
+```
+WRONG:  RED: test1,test2,test3  ->  GREEN: impl1,impl2,impl3
+RIGHT:  RED->GREEN: test1->impl1,  RED->GREEN: test2->impl2, ...
+```
+
+## Workflow
+
+### 1. Planning
+
+- [ ] Confirm which behaviors to test (prioritize with user)
+- [ ] Identify what to test vs skip (see `docs/testing-conventions.md` "What to Test" table)
+- [ ] List behaviors, not implementation steps
+- [ ] Get user approval on the plan
+
+### 2. Tracer Bullet
+
+Write ONE test confirming ONE behavior. See [gdunit4-patterns.md](gdunit4-patterns.md) for syntax.
+
+```
+RED:   Write test -> test fails
+GREEN: Write minimal code -> test passes
+```
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test -> fails
+GREEN: Minimal code to pass -> passes
+```
+
+- One test at a time, one vertical slice
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Bug fixes: name tests `test_regression_<description>`
+
+### 4. Refactor
+
+After all tests pass:
+
+- [ ] Extract duplication
+- [ ] Simplify interfaces (deep modules)
+- [ ] Run tests after each refactor step
+- [ ] **Never refactor while RED** -- get to GREEN first
+
+## Per-Cycle Checklist
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```
+
+## References
+
+- [gdunit4-patterns.md](gdunit4-patterns.md) -- assertions, lifecycle, signals, multiplayer
+- [testing-philosophy.md](testing-philosophy.md) -- deep modules, mocking, refactoring
+- `docs/testing-conventions.md` -- project naming, file structure, helpers

--- a/template/.claude/skills/tdd/gdunit4-patterns.md
+++ b/template/.claude/skills/tdd/gdunit4-patterns.md
@@ -1,0 +1,103 @@
+# gdUnit4 Patterns Reference
+
+## Test Structure
+
+```gdscript
+extends GdUnitTestSuite
+
+var subject: MyComponent
+
+
+func before_test() -> void:
+    subject = auto_free(MyComponent.new())
+    add_child(subject)
+
+
+func test_initial_state() -> void:
+    assert_bool(subject.is_active()).is_false()
+
+
+func test_activate_changes_state() -> void:
+    subject.activate()
+    assert_bool(subject.is_active()).is_true()
+```
+
+- Extend `GdUnitTestSuite`
+- `before_test()` creates fresh subject per test
+- Two blank lines between functions (gdformat)
+- One assertion concept per test
+
+## Node Lifecycle
+
+**Always**: `auto_free()` + `add_child()` with explicit type annotation:
+
+```gdscript
+# GOOD -- explicit type preserves type safety
+var node: Node2D = auto_free(Node2D.new())
+add_child(node)
+
+# BAD -- auto_free returns Variant, loses type
+var node := auto_free(Node2D.new())
+```
+
+Child nodes of an auto-freed parent don't need separate `auto_free()`.
+
+## Common Assertions
+
+| Method | Purpose | Example |
+|---|---|---|
+| `assert_int(val)` | Integer | `.is_equal(42)`, `.is_greater(0)` |
+| `assert_float(val)` | Float | `.is_equal(1.0)`, `.is_equal_approx(1.0, 0.01)` |
+| `assert_str(val)` | String | `.is_equal("stone")`, `.contains("error")` |
+| `assert_bool(val)` | Boolean | `.is_true()`, `.is_false()` |
+| `assert_object(val)` | Object/null | `.is_null()`, `.is_not_null()` |
+| `assert_array(val)` | Array | `.has_size(3)`, `.contains([item])` |
+| `assert_signal(obj)` | Signal (await) | `.call("is_emitted", "sig", [args])` |
+
+Custom failure messages: `.override_failure_message("context info")`
+
+## Signal Testing
+
+```gdscript
+func test_damage_emits_health_changed() -> void:
+    monitor_signals(health_comp)
+    health_comp.take_damage(10.0)
+    await assert_signal(health_comp).call("is_emitted", "health_changed", [90.0, 100.0])
+```
+
+- Call `monitor_signals()` BEFORE the triggering action
+- Use `.call()` syntax for `is_emitted`/`is_not_emitted`
+- Include expected args when signal has parameters
+- **Do NOT** use `monitor_signals()` on autoload singletons -- use manual signal connections instead
+
+## Autoload State Resets
+
+Reset in `before_test()` or `after_test()` to prevent test pollution.
+Add reset methods to `GdUnitTestHelper` in `tests_gdunit4/helpers/test_helper.gd` as your project grows.
+
+```gdscript
+func before_test() -> void:
+    GdUnitTestHelper.reset_my_system()  # add your own resets
+```
+
+## What to Test
+
+| Category | Test? | Example |
+|---|---|---|
+| Pure logic/calculations | Yes | `calculate_value(n)` |
+| State transitions | Yes | FSM state changes |
+| Signal emission | Yes | `value_changed` on update |
+| Data classes | Yes | Typed data containers |
+| Component behavior | Yes | `take_damage()` |
+| Visual rendering | No | Sprite appearance, animations |
+| Physics feel | Manual | Collision response, knockback |
+| UI layout | Manual | HUD positioning, menu flow |
+| Multiplayer sync | Manual | RPC delivery across peers |
+
+## Naming
+
+- Test files: `test_<module>.gd` in `tests_gdunit4/`
+- Test functions: `test_<what_is_tested>()`
+- Regression tests: `test_regression_<description>()`
+- Helper methods: `_make_<thing>()` (underscore prefix)
+- Fixtures: no leading underscore on instance variables

--- a/template/.claude/skills/tdd/testing-philosophy.md
+++ b/template/.claude/skills/tdd/testing-philosophy.md
@@ -1,0 +1,48 @@
+# Testing Philosophy
+
+## Deep Modules
+
+A deep module has a **small, simple interface** hiding **significant implementation complexity**. Test the interface, not the internals.
+
+Good: test `MyComponent.calculate_value(weight)` returns expected values for various inputs.
+Bad: test that `calculate_value` internally uses a specific formula with specific constants.
+
+When designing code for testability, prefer deep modules -- they give you a stable test surface that survives refactoring.
+
+## Mocking Guidelines
+
+**Prefer real code paths over mocks.** Most of our code can be tested with real objects using `auto_free()` + `add_child()`.
+
+**When to mock:**
+- External dependencies (network, filesystem) -- but prefer `OfflineMultiplayerPeer` for multiplayer
+- Autoload state that's expensive to reset -- but we have `GdUnitTestHelper.reset_*()` methods
+
+**When NOT to mock:**
+- Internal collaborators (components within a scene)
+- Simple data objects
+- Anything you can test directly through the public interface
+
+**Warning sign:** If your test breaks when you refactor internals but behavior hasn't changed, you're testing implementation, not behavior.
+
+## Refactoring in TDD
+
+1. **Never refactor while RED** -- get to GREEN first
+2. Run tests after each refactor step
+3. Refactoring should not change behavior -- tests must still pass
+4. Look for refactor opportunities after all tests pass:
+   - Extract duplication
+   - Simplify interfaces
+   - Move complexity behind simpler APIs
+   - Consider what new code reveals about existing code
+
+## Test Sensitivity
+
+A well-calibrated test:
+- **Fails** when user-facing behavior breaks
+- **Passes** when behavior is preserved despite internal changes
+- **Reads like a specification** -- someone unfamiliar with the code can understand what the system does
+
+A poorly-calibrated test:
+- Fails when you rename an internal function
+- Passes when actual behavior is broken
+- Tests the shape of data rather than outcomes

--- a/template/.claude/skills/triage-issue/SKILL.md
+++ b/template/.claude/skills/triage-issue/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: triage-issue
+description: Triage a bug by exploring the codebase to find root cause, then create a Ready issue with a TDD-based fix plan. Use when user reports a bug, wants to investigate a problem, or mentions "triage".
+---
+
+# Triage Issue
+
+Investigate a reported problem, find its root cause, and create a Ready issue with a TDD fix plan. Mostly hands-off -- minimize questions to the user.
+
+## Process
+
+### 1. Capture
+
+Get a brief problem description. If the user hasn't provided one, ask ONE question: "What's the problem you're seeing?" Then investigate immediately.
+
+### 2. Explore and Diagnose
+
+Use the Agent tool with `subagent_type=Explore` to deeply investigate:
+
+- **Where** the bug manifests (GDScript files, scene tree, signal handlers)
+- **What** code path is involved (trace the flow through autoloads, components, signals)
+- **Why** it fails (root cause, not just the symptom)
+- **What** related code exists (existing tests, similar working patterns, recent git changes)
+
+Check: source files in `scripts/`, existing tests in `tests_gdunit4/`, `git log` on affected files, error handling flow.
+
+### 3. Identify Fix Approach
+
+Determine: minimal change needed, affected modules/interfaces, behaviors to verify, whether this is a regression, missing feature, or design flaw.
+
+### 4. Design TDD Fix Plan
+
+Create ordered RED-GREEN cycles (vertical slices):
+
+- **RED**: Test capturing broken/missing behavior. Name regression tests `test_regression_<description>`.
+- **GREEN**: Minimal code change to pass.
+- Tests verify behavior through public interfaces, not implementation details.
+- Each test should survive internal refactors.
+- Include a REFACTOR step if needed.
+
+### 5. Create Ready Issue
+
+Run `rd create` with the investigation results. Do NOT ask the user to review first.
+
+Include in the description:
+- **Problem**: actual vs expected behavior, reproduction steps
+- **Root cause**: modules and contracts involved (not file paths or line numbers)
+- **TDD fix plan**: numbered RED-GREEN cycles
+- **Acceptance criteria**: checklist
+
+If a GitHub Issue exists, link with `--context "gh#<N>: ..."`.
+
+Print the issue ID and a one-line root cause summary when done.

--- a/template/.claude/skills/ubiquitous-language/SKILL.md
+++ b/template/.claude/skills/ubiquitous-language/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ubiquitous-language
+description: Extract domain terminology from conversations into a structured glossary at docs/UBIQUITOUS_LANGUAGE.md. Flags ambiguities, proposes canonical terms, groups by subdomain. Use when discussing domain terms, onboarding, or when terminology is ambiguous.
+---
+
+# Ubiquitous Language
+
+Extract a DDD-style glossary from the current conversation, flagging ambiguities and proposing canonical terms.
+
+## Process
+
+1. **Scan** the conversation for domain nouns and verbs
+2. **Identify problems**:
+   - **Ambiguity**: same word used for different concepts
+   - **Synonymy**: different words for the same concept
+   - **Vagueness**: imprecise or overloaded terms
+3. **Generate or update** `docs/UBIQUITOUS_LANGUAGE.md`
+
+## Output Format
+
+### Tables by Subdomain
+
+Group terms into subdomains that match your project's domain (define your own — examples: Player, World, UI, Combat, Economy, Multiplayer, etc.).
+
+| Term | Definition | Aliases to Avoid |
+|---|---|---|
+| **example term** | One-sentence definition. | synonym to avoid |
+
+### Relationships
+
+Show cardinality between key concepts:
+
+- **Entity A** has one/many **Entity B** containing zero or more **Entity C**
+
+### Flagged Ambiguities
+
+Call out terms with conflicting usage explicitly.
+
+## Rules
+
+- Definitions: one sentence max
+- Focus on project domain concepts, not generic programming terms
+- Be opinionated when choosing canonical terms over synonyms
+- Bold term names in relationship descriptions
+- Add new subdomains that match your project's actual domain — don't use this project's built-in subdomains as a starting point
+
+## Re-invocation
+
+On subsequent calls: read existing `docs/UBIQUITOUS_LANGUAGE.md`, incorporate new terms, update definitions as understanding evolves, add new subdomains if needed.

--- a/template/.claude/skills/write-a-skill/SKILL.md
+++ b/template/.claude/skills/write-a-skill/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: write-a-skill
+description: Guide creation of new Claude Code skills with proper structure, frontmatter, and trigger descriptions. Use when user wants to create, write, or add a new skill.
+---
+
+# Write a Skill
+
+Guide the user through creating a new Claude Code skill for this project.
+
+## Process
+
+### 1. Gather Requirements
+
+Ask about:
+- What task domain does this skill cover?
+- What specific use cases trigger it?
+- Does it need reference files for detailed content?
+- What tools should it be allowed to use? (optional `allowed-tools` field)
+
+### 2. Draft the Skill
+
+Create `.claude/skills/<skill-name>/SKILL.md` with:
+
+**Frontmatter** (YAML):
+```yaml
+---
+name: skill-name          # kebab-case, matches directory name
+description: ...          # CRITICAL -- see Description Rules below
+argument-hint: "<args>"   # optional, shown in UI
+allowed-tools: Read, Grep # optional, restricts available tools
+---
+```
+
+**Body**: Concise instructions. Keep SKILL.md under 100 lines.
+
+**Reference files** (if needed):
+- `REFERENCE.md` -- detailed documentation
+- `EXAMPLES.md` -- usage examples
+- Split when SKILL.md would exceed ~80 lines
+
+### 3. Review with User
+
+Present the draft, get feedback, iterate until approved.
+
+## Description Rules
+
+The description is **the only thing the agent sees** when deciding whether to load a skill. It must:
+
+- Stay under 1024 characters
+- Lead with what the skill does
+- Include trigger conditions: "Use when..."
+- Distinguish from similar skills with specific keywords
+
+**Good**: "Triage a bug by exploring the codebase to find root cause, then create a Ready issue with a TDD-based fix plan. Use when user reports a bug, wants to investigate a problem, or mentions 'triage'."
+
+**Bad**: "Help with bugs."
+
+## Examples
+
+- **Simple skill**: See `.claude/skills/cf-poll/SKILL.md` (22 lines, single workflow)
+- **Complex skill**: See `.claude/skills/review-plan/SKILL.md` (multi-step, `allowed-tools` field)
+- **With references**: See `.claude/skills/tdd/SKILL.md` (links to `gdunit4-patterns.md`, `testing-philosophy.md`)


### PR DESCRIPTION
## Task
godotsandbox-710: Skills: 6 generalized skills

## Changes
- .claude/skills/grill-me/SKILL.md: removed collision layers, specific autoloads, multiplayer details; references docs/DECISIONS.md
- .claude/skills/review-plan/SKILL.md: copied as-is (already generic)
- .claude/skills/tdd/SKILL.md + gdunit4-patterns.md + testing-philosophy.md: generalized reset methods table, no game-specific class examples
- .claude/skills/triage-issue/SKILL.md: tests_gdunit4/ instead of game-specific path
- .claude/skills/ubiquitous-language/SKILL.md: no hardcoded subdomains (Player Mechanics, Economy, etc.), instructions to define own
- .claude/skills/write-a-skill/SKILL.md: copied as-is (already generic)
- Excluded: campfires, cf-poll

## Testing
- All 6 skill files exist in .claude/skills/
- grep for tow_chain, drop_pod, enemy, Balance, ResourceBag returns empty
- grill-me references docs/DECISIONS.md (2 references)
- ubiquitous-language has no hardcoded subdomain list
- triage-issue uses tests_gdunit4/ (generic project test dir)