### PR TITLE
feat: multiplayer conditional content

### DIFF
--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -235,6 +235,20 @@ Bypass: `SKIP=gdtest git commit ...` (or `SKIP=gdtypecheck,gdtest` to skip both 
 
 See `docs/DECISIONS.md` for domain language, architectural patterns, collision layers, and key decisions.
 Update this file as the project evolves — agents reference it for project-specific context.
+{% if multiplayer %}
+## Multiplayer Patterns
+
+This project uses Godot's high-level multiplayer API with server-authoritative architecture.
+
+- **Transport**: `ENetMultiplayerPeer` for networked play, `OfflineMultiplayerPeer` for singleplayer
+- **Authority**: Server (`multiplayer.is_server()`) owns game state. Clients request actions via RPC.
+- **RPC conventions**:
+  - `@rpc("any_peer")` — client → server requests (server validates and acts)
+  - `@rpc("authority", "call_local")` — server → all clients broadcasts (including server itself)
+- **Testing**: Use `GdUnitTestHelper.setup_offline_multiplayer(self)` to make `multiplayer.is_server()` return `true` in tests
+
+See `docs/DECISIONS.md` for project-specific multiplayer decisions (NetworkManager structure, sync properties, etc.).
+{% endif %}
 
 ## Persistent Agent Memory
 

--- a/template/docs/gdscript-conventions.md.jinja
+++ b/template/docs/gdscript-conventions.md.jinja
@@ -263,3 +263,35 @@ If you encounter a warning that genuinely cannot be resolved with typed code:
 2. If not, create a new utility file with a focused purpose
 3. Add the new file to the `exclude` list in `.pre-commit-config.yaml`
 4. Never scatter `@warning_ignore` across feature code
+{% if multiplayer %}
+## Signal and RPC Type Consistency
+
+Signal declarations and their callback parameters must use matching types.
+RPC sender and receiver must use identical type annotations.
+
+```gdscript
+signal health_changed(new_health: int, max_health: int)
+
+# Callback types must match the signal declaration
+func _on_health_changed(new_health: int, max_health: int) -> void:
+    pass
+```
+
+### RPC Type Safety
+
+RPCs must use identical type annotations on both sender and receiver. Mismatched types cause runtime errors in multiplayer.
+
+```gdscript
+# Server receives from client
+@rpc("any_peer")
+func request_action(value: int) -> void:
+    pass
+
+# Client calls with same type
+func _trigger_action(value: int) -> void:
+    request_action.rpc(value)
+```
+
+Use `@rpc("authority", "call_local")` for server broadcasts that also run on the server.
+Use `@rpc("any_peer")` for client requests that the server should validate.
+{% endif %}

--- a/template/project.godot.jinja
+++ b/template/project.godot.jinja
@@ -14,6 +14,12 @@ config/name="{{ project_name }}"
 config/version="0.1.0"
 run/main_scene="res://scenes/main.tscn"
 config/features=PackedStringArray("{{ godot_version }}")
+{% if multiplayer %}
+
+[autoload]
+
+NetworkManager="*res://scripts/network/network_manager.gd"
+{% endif %}
 
 [debug]
 

--- a/template/tests_gdunit4/helpers/test_helper.gd
+++ b/template/tests_gdunit4/helpers/test_helper.gd
@@ -1,5 +1,0 @@
-## Shared test utilities for this project.
-## Add project-specific setup/reset helpers here as your project grows.
-## See docs/testing-conventions.md for patterns and conventions.
-class_name GdUnitTestHelper
-extends Object

--- a/template/tests_gdunit4/helpers/test_helper.gd.jinja
+++ b/template/tests_gdunit4/helpers/test_helper.gd.jinja
@@ -1,0 +1,15 @@
+## Shared test utilities for this project.
+## Add project-specific setup/reset helpers here as your project grows.
+## See docs/testing-conventions.md for patterns and conventions.
+class_name GdUnitTestHelper
+extends Object
+{% if multiplayer %}
+
+
+## Sets up an OfflineMultiplayerPeer so that multiplayer.is_server() returns true
+## and multiplayer.get_unique_id() returns 1. Required for testing code guarded by
+## multiplayer.is_server() in unit tests.
+static func setup_offline_multiplayer(test_suite: Node) -> void:
+	var peer := OfflineMultiplayerPeer.new()
+	test_suite.get_tree().get_multiplayer().multiplayer_peer = peer
+{% endif %}


### PR DESCRIPTION
## Task
godotsandbox-15c: Multiplayer conditional content

## Changes
- project.godot.jinja: Jinja2 conditional adds [autoload] NetworkManager only when multiplayer=true
- CLAUDE.md.jinja: Multiplayer Patterns section (RPC conventions, server-authoritative, OfflineMultiplayerPeer) present only when multiplayer=true
- docs/gdscript-conventions.md.jinja: renamed from .md, RPC Type Consistency section appended conditionally
- tests_gdunit4/helpers/test_helper.gd.jinja: replaces static .gd; setup_offline_multiplayer() method conditional on multiplayer=true

## Testing
- copier copy --defaults --trust --data multiplayer=true: project.godot contains NetworkManager autoload
- copier copy --defaults --trust --data multiplayer=false: project.godot has no NetworkManager
- CLAUDE.md Multiplayer Patterns section: present only with multiplayer=true (grepped)
- test_helper.gd setup_offline_multiplayer: present only with multiplayer=true
- gdscript-conventions.md RPC Type Safety section: present only with multiplayer=true