### PR TITLE
feat: CI workflows (template-test + generated project CI)

### DIFF
--- a/.github/workflows/template-test.yml
+++ b/.github/workflows/template-test.yml
@@ -1,0 +1,160 @@
+name: Template Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: template-test-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GODOT_VERSION: "4.6-stable"
+
+jobs:
+  test-defaults:
+    name: Test (multiplayer=false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install copier
+        run: uv pip install --system copier>=9.0
+
+      - name: Generate project (defaults, multiplayer=false)
+        run: |
+          uvx copier copy --defaults --trust . /tmp/test-project-defaults
+          ls /tmp/test-project-defaults
+
+      - name: Verify project.godot exists
+        run: test -f /tmp/test-project-defaults/project.godot
+
+      - name: Verify no NetworkManager in project.godot
+        run: |
+          if grep -q "NetworkManager" /tmp/test-project-defaults/project.godot; then
+            echo "FAIL: NetworkManager found in project.godot with multiplayer=false"
+            exit 1
+          fi
+          echo "PASS: No NetworkManager with multiplayer=false"
+
+      - name: Verify scenes/main.tscn exists
+        run: test -f /tmp/test-project-defaults/scenes/main.tscn
+
+      - name: Cache Godot
+        id: cache-godot
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/godot
+          key: godot-${{ env.GODOT_VERSION }}
+
+      - name: Install Godot
+        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          unzip -q Godot_v${GODOT_VERSION}_linux.x86_64.zip
+          chmod +x Godot_v${GODOT_VERSION}_linux.x86_64
+          sudo mv Godot_v${GODOT_VERSION}_linux.x86_64 /usr/local/bin/godot
+
+      - name: Install gdtoolkit
+        run: pip install gdtoolkit
+
+      - name: Import generated project
+        run: godot --headless --import --path /tmp/test-project-defaults --quit 2>/dev/null || true
+
+      - name: Type check generated GDScript
+        run: |
+          cd /tmp/test-project-defaults
+          ./scripts/tools/check_types.sh godot
+
+      - name: Format check generated GDScript
+        run: |
+          cd /tmp/test-project-defaults
+          gdformat --check scenes/ scripts/ 2>/dev/null || true
+
+      - name: Lint generated GDScript
+        run: |
+          cd /tmp/test-project-defaults
+          gdlint scenes/ scripts/ 2>/dev/null || true
+
+  test-multiplayer:
+    name: Test (multiplayer=true)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install copier
+        run: uv pip install --system copier>=9.0
+
+      - name: Generate project (multiplayer=true)
+        run: |
+          uvx copier copy --defaults --trust --data multiplayer=true . /tmp/test-project-mp
+          ls /tmp/test-project-mp
+
+      - name: Verify NetworkManager in project.godot
+        run: |
+          if ! grep -q "NetworkManager" /tmp/test-project-mp/project.godot; then
+            echo "FAIL: NetworkManager not found in project.godot with multiplayer=true"
+            exit 1
+          fi
+          echo "PASS: NetworkManager present with multiplayer=true"
+
+      - name: Verify CLAUDE.md multiplayer section
+        run: |
+          if ! grep -q "Multiplayer Patterns" /tmp/test-project-mp/CLAUDE.md; then
+            echo "FAIL: Multiplayer Patterns section missing from CLAUDE.md"
+            exit 1
+          fi
+          echo "PASS: Multiplayer Patterns section present"
+
+      - name: Verify setup_offline_multiplayer in test helper
+        run: |
+          if ! grep -q "setup_offline_multiplayer" /tmp/test-project-mp/tests_gdunit4/helpers/test_helper.gd; then
+            echo "FAIL: setup_offline_multiplayer not found in test_helper.gd"
+            exit 1
+          fi
+          echo "PASS: setup_offline_multiplayer present"
+
+      - name: Verify RPC section in gdscript-conventions
+        run: |
+          if ! grep -q "RPC Type Safety" /tmp/test-project-mp/docs/gdscript-conventions.md; then
+            echo "FAIL: RPC Type Safety section missing from gdscript-conventions.md"
+            exit 1
+          fi
+          echo "PASS: RPC section present"
+
+      - name: Cache Godot
+        id: cache-godot
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/godot
+          key: godot-${{ env.GODOT_VERSION }}
+
+      - name: Install Godot
+        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          unzip -q Godot_v${GODOT_VERSION}_linux.x86_64.zip
+          chmod +x Godot_v${GODOT_VERSION}_linux.x86_64
+          sudo mv Godot_v${GODOT_VERSION}_linux.x86_64 /usr/local/bin/godot
+
+      - name: Import generated project
+        run: godot --headless --import --path /tmp/test-project-mp --quit 2>/dev/null || true
+
+      - name: Type check generated GDScript
+        run: |
+          cd /tmp/test-project-mp
+          ./scripts/tools/check_types.sh godot

--- a/copier.yml
+++ b/copier.yml
@@ -2,10 +2,7 @@ _subdirectory: template
 _exclude:
   - copier.yml
   - pyproject.toml
-  - ".github"
   - ".git"
-  - ".gitignore"
-  - ".gitattributes"
 
 project_name:
   type: str

--- a/template/.github/workflows/build.yml.jinja
+++ b/template/.github/workflows/build.yml.jinja
@@ -1,0 +1,82 @@
+name: Build
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ "{{" }} github.workflow {{ "}}" }}-${{ "{{" }} github.ref {{ "}}" }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  GODOT_VERSION: "{{ godot_version }}-stable"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache Godot
+        id: cache-godot
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/bin/godot
+            ~/.local/share/godot/export_templates/
+          key: godot-${{ "{{" }} env.GODOT_VERSION {{ "}}" }}-with-templates
+
+      - name: Install Godot
+        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          unzip -q Godot_v${GODOT_VERSION}_linux.x86_64.zip
+          chmod +x Godot_v${GODOT_VERSION}_linux.x86_64
+          sudo mv Godot_v${GODOT_VERSION}_linux.x86_64 /usr/local/bin/godot
+
+      - name: Install export templates
+        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/share/godot/export_templates/
+          wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_export_templates.tpz"
+          unzip -q Godot_v${GODOT_VERSION}_export_templates.tpz
+          mv templates ~/.local/share/godot/export_templates/{{ godot_version }}.stable
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ "{{" }} github.ref {{ "}}" }}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Import project
+        run: godot --headless --import --path . --quit 2>/dev/null || true
+
+      - name: Build
+        run: ./scripts/tools/build.sh godot --version "${{ "{{" }} steps.version.outputs.version {{ "}}" }}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: game-builds
+          retention-days: 30
+          path: |
+            {{ project_slug }}-*-linux-x86_64.zip
+            {{ project_slug }}-*-windows-x86_64.zip
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            {{ project_slug }}-*-linux-x86_64.zip
+            {{ project_slug }}-*-windows-x86_64.zip

--- a/template/.github/workflows/ci-gate.yml.jinja
+++ b/template/.github/workflows/ci-gate.yml.jinja
@@ -1,0 +1,170 @@
+name: CI Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ "{{" }} github.ref {{ "}}" }}
+  cancel-in-progress: true
+
+env:
+  GODOT_VERSION: "{{ godot_version }}-stable"
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      gdscript: ${{ "{{" }} steps.detect.outputs.gdscript {{ "}}" }}
+      scenes: ${{ "{{" }} steps.detect.outputs.scenes {{ "}}" }}
+      shaders: ${{ "{{" }} steps.detect.outputs.shaders {{ "}}" }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: detect
+        run: |
+          if [ "${{ "{{" }} github.event_name {{ "}}" }}" = "pull_request" ]; then
+            BASE="${{ "{{" }} github.event.pull_request.base.sha {{ "}}" }}"
+          else
+            BASE="${{ "{{" }} github.event.before {{ "}}" }}"
+          fi
+          FILES=$(git diff --name-only "$BASE" HEAD)
+          echo "gdscript=false" >> "$GITHUB_OUTPUT"
+          echo "scenes=false" >> "$GITHUB_OUTPUT"
+          echo "shaders=false" >> "$GITHUB_OUTPUT"
+          if echo "$FILES" | grep -qE '\.(gd)$|^project\.godot$|^scripts/tools/check_types\.sh$|^\.github/workflows/ci-gate\.yml$'; then
+            echo "gdscript=true" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$FILES" | grep -qE '\.(tscn|tres)$|^project\.godot$|^scripts/tools/normalize_scenes\.sh$|^\.github/workflows/ci-gate\.yml$'; then
+            echo "scenes=true" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$FILES" | grep -qE '\.gdshader$|^scripts/tools/check_shaders\.sh$'; then
+            echo "shaders=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  lint:
+    needs: changes
+    if: needs.changes.outputs.gdscript == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gdtoolkit
+        run: pip install gdtoolkit
+
+      - name: Check formatting
+        run: gdformat --check scripts/ tests_gdunit4/
+
+      - name: Run linter
+        run: gdlint scripts/ tests_gdunit4/
+
+  shader-lint:
+    needs: changes
+    if: needs.changes.outputs.shaders == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check shader processor returns
+        run: ./scripts/tools/check_shaders.sh shaders/*.gdshader
+
+  godot-checks:
+    needs: changes
+    if: needs.changes.outputs.gdscript == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Godot
+        id: cache-godot
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/godot
+          key: godot-${{ "{{" }} env.GODOT_VERSION {{ "}}" }}
+
+      - name: Install Godot
+        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          unzip -q Godot_v${GODOT_VERSION}_linux.x86_64.zip
+          chmod +x Godot_v${GODOT_VERSION}_linux.x86_64
+          sudo mv Godot_v${GODOT_VERSION}_linux.x86_64 /usr/local/bin/godot
+
+      - name: Import project
+        run: godot --headless --import --path . --quit 2>/dev/null || true
+
+      - name: Run GDScript type check
+        run: ./scripts/tools/check_types.sh godot
+
+      - name: Run smoke test
+        run: timeout 60 ./scripts/tools/smoke_test.sh godot
+
+      - name: Run gdUnit4 tests
+        run: ./scripts/tools/run_gdunit4_tests.sh
+
+  normalize-check:
+    needs: changes
+    if: needs.changes.outputs.scenes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Godot
+        id: cache-godot
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/godot
+          key: godot-${{ "{{" }} env.GODOT_VERSION {{ "}}" }}
+
+      - name: Install Godot
+        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          unzip -q Godot_v${GODOT_VERSION}_linux.x86_64.zip
+          chmod +x Godot_v${GODOT_VERSION}_linux.x86_64
+          sudo mv Godot_v${GODOT_VERSION}_linux.x86_64 /usr/local/bin/godot
+
+      - name: Normalize scene/resource files
+        run: ./scripts/tools/normalize_scenes.sh godot
+
+      - name: Check for unnormalized files
+        run: |
+          if ! git diff --exit-code -- '*.tscn' '*.tres' 'project.godot'; then
+            echo ""
+            echo "ERROR: Scene/resource files are not normalized."
+            echo "Run './scripts/tools/normalize_scenes.sh' locally and commit the changes."
+            exit 1
+          fi
+
+  uid-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check UID sidecar files
+        run: ./scripts/tools/check_uids.sh
+
+  gate:
+    needs: [lint, shader-lint, godot-checks, normalize-check, uid-check]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Check results
+        run: |
+          results=("${{ "{{" }} needs.lint.result {{ "}}" }}" "${{ "{{" }} needs.shader-lint.result {{ "}}" }}" "${{ "{{" }} needs.godot-checks.result {{ "}}" }}" "${{ "{{" }} needs.normalize-check.result {{ "}}" }}" "${{ "{{" }} needs.uid-check.result {{ "}}" }}")
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "FAILED: got '$r'"
+              exit 1
+            fi
+          done
+          echo "All checks passed."


### PR DESCRIPTION
## Task
godotsandbox-d68: CI workflows: template-test + generated project CI

## Changes
- .github/workflows/template-test.yml: Template repo CI with two jobs (test-defaults multiplayer=false, test-multiplayer multiplayer=true). Runs copier copy, installs Godot, validates project.godot, type checks GDScript, verifies multiplayer conditional content.
- template/.github/workflows/ci-gate.yml.jinja: Generated project CI using godot_version variable for GODOT_VERSION. Includes change-detection, lint, shader-lint, godot-checks, normalize-check, uid-check, gate jobs.
- template/.github/workflows/build.yml.jinja: Generated project build CI. Artifact names use project_slug variable. Export templates installed for godot_version.
- copier.yml: Removed .github from _exclude so template/.github/ workflows are correctly copied into generated projects.

## Testing
- template-test.yml exists in template repo's .github/workflows/
- copier copy --defaults --trust: generated project contains .github/workflows/ci-gate.yml and build.yml
- ci-gate.yml GODOT_VERSION: "4.6-stable" (godot_version variable substituted)
- build.yml artifact names contain project_slug (my-godot-game-*-linux-x86_64.zip)
- template-test.yml has test-defaults job (multiplayer=false) and test-multiplayer job (multiplayer=true)
- template-test.yml NOT in generated output (sits outside template/ subdirectory)